### PR TITLE
Fix student login redirect to dashboard

### DIFF
--- a/src/app/student/login/page.tsx
+++ b/src/app/student/login/page.tsx
@@ -109,7 +109,8 @@ function StudentLoginContent() {
         })
         setLoadingMessage('Mengalihkan ke dashboard...')
 
-        const targetUrl = result.url ?? callbackUrl
+        const isAuthSignInPage = result.url?.includes('/api/auth/signin')
+        const targetUrl = (!isAuthSignInPage && result.url) ? result.url : callbackUrl
         console.log('[StudentLogin] Navigation target after sign-in:', targetUrl)
 
         if (!targetUrl) {


### PR DESCRIPTION
## Summary
- ensure student login redirects to the dashboard instead of looping back to the NextAuth sign-in form by falling back to the callback URL when NextAuth returns its own sign-in URL

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d75325b308832685263b44afbde1b9