### PR TITLE
Fix WebRTC live session routes for Next.js build

### DIFF
--- a/README-live.md
+++ b/README-live.md
@@ -1,0 +1,46 @@
+# Live Classroom Streaming Guide
+
+This document describes the WebRTC + WebSocket live classroom feature for the GEMA SMA Wahidiyah platform.
+
+## Environment variables
+
+Add the following variables to your environment (e.g. `.env.local`):
+
+```
+# Signaling / RTC
+NEXT_PUBLIC_STUN_URLS='["stun:stun.l.google.com:19302"]'
+NEXT_PUBLIC_TURN_URL=
+NEXT_PUBLIC_TURN_USERNAME=
+NEXT_PUBLIC_TURN_PASSWORD=
+
+# Cloudinary
+CLOUDINARY_CLOUD_NAME=
+CLOUDINARY_API_KEY=
+CLOUDINARY_API_SECRET=
+```
+
+* Provide TURN credentials in production so sessions continue behind restrictive networks.
+* The Cloudinary keys are used server side to sign uploads; never expose the secret outside the server route.
+
+## Development
+
+1. Install dependencies and run Prisma generate if needed.
+2. Start the dev server with `npm run dev`.
+3. Visit `/classroom/<classroomId>/live`.
+4. Login as admin to host (NextAuth). Students join via the student login flow.
+
+The in-memory signaling store is suitable for local development. For production, replace it with Redis/Upstash by adapting the `RoomStore` implementation in `src/app/api/ws/route.ts`.
+
+## Feature overview
+
+* Host (admin) can start a live session, broadcast audio/video, share their screen, and record locally.
+* Viewers (students) join the live room via a lightweight WebSocket signaling channel and connect using WebRTC (mesh topology).
+* MediaRecorder captures the host stream and uploads it to Cloudinary when stopped. The secure URL is stored on `LiveSession.recordingUrl` when the session ends.
+* Edge WebSocket route supports multiple rooms and enforces host/viewer signaling rules.
+
+## Limitations & follow ups
+
+* State is in-memory; restart clears live rooms. Use Upstash/Redis in production.
+* TURN credentials are required for audiences on strict networks.
+* Recording happens only on the host device. Ensure adequate disk/CPU before running long recordings.
+* There is minimal retry logic; refresh the page to recover from fatal signaling failures.

--- a/prisma/migrations/20250205120000_add_live_sessions_attendance/migration.sql
+++ b/prisma/migrations/20250205120000_add_live_sessions_attendance/migration.sql
@@ -1,0 +1,36 @@
+CREATE TABLE "classrooms" (
+    "id" TEXT PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "slug" TEXT UNIQUE,
+    "description" TEXT,
+    "teacherId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE "live_sessions" (
+    "id" TEXT PRIMARY KEY,
+    "classroomId" TEXT NOT NULL,
+    "startsAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+    "endsAt" TIMESTAMP,
+    "status" TEXT NOT NULL DEFAULT 'scheduled',
+    "recordingUrl" TEXT,
+    "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT "live_sessions_classroomId_fkey" FOREIGN KEY ("classroomId") REFERENCES "classrooms" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "live_sessions_classroomId_idx" ON "live_sessions" ("classroomId");
+
+CREATE TABLE "attendances" (
+    "id" TEXT PRIMARY KEY,
+    "sessionId" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "joinedAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+    "leftAt" TIMESTAMP,
+    CONSTRAINT "attendances_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "live_sessions" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "attendances_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "students" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "attendances_sessionId_studentId_key" ON "attendances" ("sessionId", "studentId");
+CREATE INDEX "attendances_studentId_idx" ON "attendances" ("studentId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -342,6 +342,52 @@ model ClassroomProjectChecklist {
   @@map("classroom_project_checklists")
 }
 
+model Classroom {
+  id          String        @id @default(cuid())
+  title       String
+  slug        String?       @unique
+  description String?
+  teacherId   String
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  liveSessions LiveSession[]
+
+  @@map("classrooms")
+}
+
+model LiveSession {
+  id           String      @id @default(cuid())
+  classroomId  String
+  startsAt     DateTime    @default(now())
+  endsAt       DateTime?
+  status       String      @default("scheduled")
+  recordingUrl String?
+  createdAt    DateTime    @default(now())
+  updatedAt    DateTime    @updatedAt
+
+  classroom   Classroom  @relation(fields: [classroomId], references: [id], onDelete: Cascade)
+  attendances Attendance[]
+
+  @@index([classroomId])
+  @@map("live_sessions")
+}
+
+model Attendance {
+  id        String   @id @default(cuid())
+  sessionId String
+  studentId String
+  joinedAt  DateTime @default(now())
+  leftAt    DateTime?
+
+  session LiveSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  student Student     @relation(fields: [studentId], references: [id], onDelete: Cascade)
+
+  @@unique([sessionId, studentId])
+  @@index([studentId])
+  @@map("attendances")
+}
+
 model Student {
   id           String    @id @default(cuid())
   studentId    String    @unique // NIS atau nomor identitas siswa
@@ -365,6 +411,7 @@ model Student {
   submissions         Submission[]
   PortfolioSubmission PortfolioSubmission[]
   ArticleFeedback     ArticleFeedback[]
+  attendances         Attendance[]
 
   @@index([studentId])
   @@index([status])

--- a/src/app/api/classroom/[id]/session/end/route.ts
+++ b/src/app/api/classroom/[id]/session/end/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+
+import { prisma } from '@/lib/prisma'
+import { authOptions } from '@/lib/auth-config'
+
+export async function POST(request: NextRequest) {
+  const segments = request.nextUrl.pathname.split('/').filter(Boolean)
+  const classroomIndex = segments.indexOf('classroom')
+  const classroomId = classroomIndex !== -1 ? segments[classroomIndex + 1] : undefined
+
+  const session = await getServerSession(authOptions)
+
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  if (!classroomId) {
+    return NextResponse.json({ error: 'Classroom id is required' }, { status: 400 })
+  }
+
+  const { sessionId, recordingUrl }: { sessionId?: string; recordingUrl?: string | null } =
+    await request.json()
+
+  if (!sessionId) {
+    return NextResponse.json({ error: 'Session id is required' }, { status: 400 })
+  }
+
+  const liveSession = await prisma.liveSession.findUnique({
+    where: { id: sessionId }
+  })
+
+  if (!liveSession || liveSession.classroomId !== classroomId) {
+    return NextResponse.json({ error: 'Live session not found' }, { status: 404 })
+  }
+
+  const updatedSession = await prisma.liveSession.update({
+    where: { id: sessionId },
+    data: {
+      status: 'ended',
+      endsAt: new Date(),
+      recordingUrl: recordingUrl ?? liveSession.recordingUrl ?? null
+    }
+  })
+
+  return NextResponse.json({ session: updatedSession })
+}

--- a/src/app/api/classroom/[id]/session/start/route.ts
+++ b/src/app/api/classroom/[id]/session/start/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+
+import { prisma } from '@/lib/prisma'
+import { authOptions } from '@/lib/auth-config'
+
+export async function POST(request: NextRequest) {
+  const segments = request.nextUrl.pathname.split('/').filter(Boolean)
+  const classroomIndex = segments.indexOf('classroom')
+  const classroomId = classroomIndex !== -1 ? segments[classroomIndex + 1] : undefined
+
+  const session = await getServerSession(authOptions)
+
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  if (!classroomId) {
+    return NextResponse.json({ error: 'Classroom id is required' }, { status: 400 })
+  }
+
+  const classroom = await prisma.classroom.findUnique({
+    where: { id: classroomId }
+  })
+
+  if (!classroom) {
+    return NextResponse.json({ error: 'Classroom not found' }, { status: 404 })
+  }
+
+  const existingLiveSession = await prisma.liveSession.findFirst({
+    where: {
+      classroomId,
+      status: 'live'
+    }
+  })
+
+  if (existingLiveSession) {
+    return NextResponse.json(
+      { error: 'Live session already active', session: existingLiveSession },
+      { status: 400 }
+    )
+  }
+
+  const liveSession = await prisma.liveSession.create({
+    data: {
+      classroomId,
+      status: 'live',
+      startsAt: new Date()
+    }
+  })
+
+  return NextResponse.json({ session: liveSession })
+}

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,0 +1,59 @@
+import crypto from 'crypto'
+import { NextRequest, NextResponse } from 'next/server'
+
+const CLOUDINARY_SECRET = process.env.CLOUDINARY_API_SECRET
+const CLOUDINARY_API_KEY = process.env.CLOUDINARY_API_KEY
+const CLOUDINARY_CLOUD_NAME = process.env.CLOUDINARY_CLOUD_NAME
+
+if (!CLOUDINARY_SECRET || !CLOUDINARY_API_KEY || !CLOUDINARY_CLOUD_NAME) {
+  console.warn('Cloudinary environment variables are not fully configured')
+}
+
+export async function POST(request: NextRequest) {
+  if (!CLOUDINARY_SECRET || !CLOUDINARY_API_KEY || !CLOUDINARY_CLOUD_NAME) {
+    return NextResponse.json({ error: 'Cloudinary is not configured' }, { status: 500 })
+  }
+
+  let body: { folder?: string; publicId?: string } = {}
+  try {
+    body = await request.json()
+  } catch (error) {
+    console.warn('Failed to parse Cloudinary sign request body', error)
+  }
+
+  const timestamp = Math.round(Date.now() / 1000)
+  const params: Record<string, string> = {
+    timestamp: String(timestamp)
+  }
+
+  if (body.folder) {
+    params.folder = body.folder
+  }
+
+  if (body.publicId) {
+    params.public_id = body.publicId
+  }
+
+  const signatureBase = Object.keys(params)
+    .sort()
+    .map((key) => `${key}=${params[key]}`)
+    .join('&')
+
+  const signature = crypto
+    .createHash('sha1')
+    .update(signatureBase + CLOUDINARY_SECRET)
+    .digest('hex')
+
+  return NextResponse.json({
+    timestamp,
+    signature,
+    apiKey: CLOUDINARY_API_KEY,
+    cloudName: CLOUDINARY_CLOUD_NAME,
+    folder: body.folder,
+    publicId: body.publicId
+  })
+}
+
+export function GET() {
+  return NextResponse.json({ error: 'Method not allowed' }, { status: 405 })
+}

--- a/src/app/api/ws/route.ts
+++ b/src/app/api/ws/route.ts
@@ -1,0 +1,324 @@
+import type { NextRequest } from 'next/server'
+
+export const runtime = 'edge'
+
+type Role = 'host' | 'viewer'
+
+type JoinMessage = {
+  type: 'join'
+  roomId: string
+  clientId: string
+  role: Role
+}
+
+type SignalMessage = {
+  type: 'offer' | 'answer'
+  roomId: string
+  clientId: string
+  target: string
+  sdp: string
+}
+
+type IceMessage = {
+  type: 'ice'
+  roomId: string
+  clientId: string
+  target: string
+  candidate: RTCIceCandidateInit
+}
+
+type IncomingMessage = JoinMessage | SignalMessage | IceMessage
+
+type OutgoingMessage =
+  | {
+      type: 'joined'
+      clientId: string
+      role: Role
+      peers: Array<{ clientId: string; role: Role }>
+    }
+  | {
+      type: 'peer-joined' | 'peer-left'
+      clientId: string
+      role?: Role
+    }
+  | ({
+      type: 'offer' | 'answer'
+    } & {
+      clientId: string
+      target: string
+      sdp: string
+    })
+  | ({
+      type: 'ice'
+    } & {
+      clientId: string
+      target: string
+      candidate: RTCIceCandidateInit
+    })
+  | {
+      type: 'error'
+      message: string
+    }
+
+type WebSocketResponseInit = ResponseInit & { webSocket: WebSocket }
+
+interface PeerRecord {
+  id: string
+  socket: WebSocket
+  role: Role
+}
+
+interface RoomStore {
+  addPeer(roomId: string, peer: PeerRecord): { peers: PeerRecord[]; isNewHost: boolean }
+  removePeer(roomId: string, peerId: string): PeerRecord | null
+  getPeer(roomId: string, peerId: string): PeerRecord | null
+  listPeers(roomId: string): PeerRecord[]
+  hasHost(roomId: string): boolean
+}
+
+class InMemoryRoomStore implements RoomStore {
+  private rooms = new Map<string, Map<string, PeerRecord>>()
+
+  addPeer(roomId: string, peer: PeerRecord) {
+    let room = this.rooms.get(roomId)
+    if (!room) {
+      room = new Map()
+      this.rooms.set(roomId, room)
+    }
+
+    const isNewHost = peer.role === 'host'
+    room.set(peer.id, peer)
+
+    return {
+      peers: Array.from(room.values()),
+      isNewHost
+    }
+  }
+
+  removePeer(roomId: string, peerId: string) {
+    const room = this.rooms.get(roomId)
+    if (!room) {
+      return null
+    }
+
+    const peer = room.get(peerId) ?? null
+    if (peer) {
+      room.delete(peerId)
+    }
+
+    if (room.size === 0) {
+      this.rooms.delete(roomId)
+    }
+
+    return peer
+  }
+
+  getPeer(roomId: string, peerId: string) {
+    return this.rooms.get(roomId)?.get(peerId) ?? null
+  }
+
+  listPeers(roomId: string) {
+    return Array.from(this.rooms.get(roomId)?.values() ?? [])
+  }
+
+  hasHost(roomId: string) {
+    return this.listPeers(roomId).some((peer) => peer.role === 'host')
+  }
+}
+
+const store: RoomStore = new InMemoryRoomStore()
+
+function broadcast(roomId: string, payload: OutgoingMessage, excludeId?: string) {
+  const peers = store.listPeers(roomId)
+  const message = JSON.stringify(payload)
+  for (const peer of peers) {
+    if (peer.id === excludeId) continue
+    try {
+      peer.socket.send(message)
+    } catch (error) {
+      console.error('Failed to broadcast message', error)
+    }
+  }
+}
+
+function send(socket: WebSocket, payload: OutgoingMessage) {
+  try {
+    socket.send(JSON.stringify(payload))
+  } catch (error) {
+    console.error('Failed to send message', error)
+  }
+}
+
+export function GET(request: NextRequest) {
+  if (request.headers.get('upgrade')?.toLowerCase() !== 'websocket') {
+    return new Response('Expected websocket', { status: 400 })
+  }
+
+  const { WebSocketPair } = globalThis as unknown as {
+    WebSocketPair: new () => { 0: WebSocket; 1: WebSocket }
+  }
+  const pair = new WebSocketPair()
+  const client = pair[0]
+  const server = pair[1] as WebSocket & { accept: () => void }
+
+  const peerState: {
+    roomId: string | null
+    clientId: string | null
+  } = {
+    roomId: null,
+    clientId: null
+  }
+
+  server.accept()
+
+  server.addEventListener('message', (event) => {
+    try {
+      const data = JSON.parse(event.data as string) as IncomingMessage
+      if (data.type === 'join') {
+        handleJoin(server, data, peerState)
+        return
+      }
+
+      if (!peerState.roomId || !peerState.clientId) {
+        send(server, { type: 'error', message: 'Join a room before sending signals' })
+        return
+      }
+
+      handleSignal(server, data, peerState as { roomId: string; clientId: string })
+    } catch (error) {
+      console.error('Failed to parse message', error)
+      send(server, { type: 'error', message: 'Invalid message payload' })
+    }
+  })
+
+  const close = () => {
+    const { roomId, clientId } = peerState
+    if (!roomId || !clientId) {
+      return
+    }
+
+    const peer = store.removePeer(roomId, clientId)
+    if (peer) {
+      broadcast(roomId, { type: 'peer-left', clientId: peer.id }, peer.id)
+    }
+
+    peerState.roomId = null
+    peerState.clientId = null
+  }
+
+  server.addEventListener('close', close)
+  server.addEventListener('error', close)
+
+  const responseInit: WebSocketResponseInit = { status: 101, webSocket: client }
+  return new Response(null, responseInit)
+}
+
+function handleJoin(socket: WebSocket, data: JoinMessage, state: { roomId: string | null; clientId: string | null }) {
+  const { roomId, clientId, role } = data
+
+  if (!roomId || !clientId || !role) {
+    send(socket, { type: 'error', message: 'Invalid join payload' })
+    return
+  }
+
+  if (role === 'host' && store.hasHost(roomId)) {
+    send(socket, { type: 'error', message: 'Host already connected' })
+    socket.close()
+    return
+  }
+
+  state.roomId = roomId
+  state.clientId = clientId
+
+  store.addPeer(roomId, {
+    id: clientId,
+    role,
+    socket
+  })
+
+  const peers = store.listPeers(roomId).map((peer) => ({
+    clientId: peer.id,
+    role: peer.role
+  }))
+
+  send(socket, {
+    type: 'joined',
+    clientId,
+    role,
+    peers
+  })
+
+  broadcast(roomId, { type: 'peer-joined', clientId, role }, clientId)
+}
+
+function handleSignal(socket: WebSocket, data: IncomingMessage, state: { roomId: string; clientId: string }) {
+  const roomId = state.roomId
+  const senderId = state.clientId
+  const sender = store.getPeer(roomId, senderId)
+
+  if (!sender) {
+    send(socket, { type: 'error', message: 'Sender not registered in room' })
+    return
+  }
+
+  switch (data.type) {
+    case 'offer': {
+      if (sender.role !== 'host') {
+        send(socket, { type: 'error', message: 'Only hosts can send offers' })
+        return
+      }
+
+      const target = store.getPeer(roomId, data.target)
+      if (!target) {
+        send(socket, { type: 'error', message: 'Target peer not found' })
+        return
+      }
+
+      send(target.socket, {
+        type: 'offer',
+        clientId: senderId,
+        target: data.target,
+        sdp: data.sdp
+      })
+      return
+    }
+    case 'answer': {
+      if (sender.role !== 'viewer') {
+        send(socket, { type: 'error', message: 'Only viewers can send answers' })
+        return
+      }
+
+      const target = store.getPeer(roomId, data.target)
+      if (!target) {
+        send(socket, { type: 'error', message: 'Host not found for answer' })
+        return
+      }
+
+      send(target.socket, {
+        type: 'answer',
+        clientId: senderId,
+        target: data.target,
+        sdp: data.sdp
+      })
+      return
+    }
+    case 'ice': {
+      const target = store.getPeer(roomId, data.target)
+      if (!target) {
+        send(socket, { type: 'error', message: 'Peer not found for ICE candidate' })
+        return
+      }
+
+      send(target.socket, {
+        type: 'ice',
+        clientId: senderId,
+        target: data.target,
+        candidate: data.candidate
+      })
+      return
+    }
+    default: {
+      send(socket, { type: 'error', message: 'Unsupported message type' })
+    }
+  }
+}

--- a/src/app/classroom/[id]/live/page.tsx
+++ b/src/app/classroom/[id]/live/page.tsx
@@ -1,0 +1,1057 @@
+'use client'
+
+import { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { useSession } from 'next-auth/react'
+import {
+  AlertCircle,
+  CheckCircle2,
+  Loader2,
+  Monitor,
+  Play,
+  ScreenShare,
+  ScreenShareOff,
+  Square,
+  UploadCloud,
+  Users,
+  Video
+} from 'lucide-react'
+
+import { studentAuth } from '@/lib/student-auth'
+import { useRecorder } from '@/hooks/useRecorder'
+import { uploadRecordingToCloudinary } from '@/lib/cloudinaryUpload'
+
+type Role = 'host' | 'viewer'
+
+type ServerMessage =
+  | {
+      type: 'joined'
+      clientId: string
+      role: Role
+      peers: Array<{ clientId: string; role: Role }>
+    }
+  | {
+      type: 'peer-joined'
+      clientId: string
+      role: Role
+    }
+  | {
+      type: 'peer-left'
+      clientId: string
+    }
+  | {
+      type: 'offer' | 'answer'
+      clientId: string
+      target: string
+      sdp: string
+    }
+  | {
+      type: 'ice'
+      clientId: string
+      target: string
+      candidate: RTCIceCandidateInit
+    }
+  | {
+      type: 'error'
+      message: string
+    }
+
+type ConnectionStatus = 'idle' | 'initializing' | 'connecting' | 'connected' | 'error'
+
+type VideoPreviewProps = {
+  stream: MediaStream | null
+  muted?: boolean
+  label: string
+  placeholder?: string
+}
+
+const FALLBACK_STUN = ['stun:stun.l.google.com:19302']
+
+function resolveIceServers(): RTCIceServer[] {
+  const servers: RTCIceServer[] = []
+  const stunEnv = process.env.NEXT_PUBLIC_STUN_URLS
+
+  if (stunEnv) {
+    try {
+      const parsed = JSON.parse(stunEnv)
+      if (Array.isArray(parsed) && parsed.length) {
+        servers.push({ urls: parsed })
+      }
+    } catch (error) {
+      console.warn('Failed to parse NEXT_PUBLIC_STUN_URLS', error)
+    }
+  }
+
+  if (!servers.length) {
+    servers.push({ urls: FALLBACK_STUN })
+  }
+
+  const turnUrl = process.env.NEXT_PUBLIC_TURN_URL
+  const turnUsername = process.env.NEXT_PUBLIC_TURN_USERNAME
+  const turnPassword = process.env.NEXT_PUBLIC_TURN_PASSWORD
+
+  if (turnUrl && turnUsername && turnPassword) {
+    servers.push({
+      urls: turnUrl,
+      username: turnUsername,
+      credential: turnPassword
+    })
+  }
+
+  return servers
+}
+export default function LiveClassroomPage() {
+  const params = useParams<{ id: string }>()
+  const classroomIdParam = Array.isArray(params?.id) ? params.id[0] : params?.id
+  const roomId = classroomIdParam || ''
+  const { data: authSession } = useSession()
+  const [studentSession, setStudentSession] = useState<ReturnType<typeof studentAuth.getSession> | null>(null)
+
+  useEffect(() => {
+    setStudentSession(studentAuth.getSession())
+  }, [])
+
+  const isAdmin = authSession?.user?.role === 'ADMIN'
+
+  if (!roomId) {
+    return (
+      <div className="min-h-screen bg-slate-950 text-white flex items-center justify-center">
+        <div className="text-center space-y-2">
+          <AlertCircle className="mx-auto h-12 w-12 text-red-500" />
+          <p className="text-lg font-semibold">Classroom tidak ditemukan</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!isAdmin && !studentSession) {
+    return (
+      <div className="min-h-screen bg-slate-950 text-white flex items-center justify-center px-6">
+        <div className="max-w-md text-center space-y-4">
+          <AlertCircle className="mx-auto h-12 w-12 text-yellow-400" />
+          <h1 className="text-2xl font-semibold">Masuk untuk bergabung</h1>
+          <p className="text-slate-300">
+            Siaran langsung hanya dapat diakses oleh guru (admin) dan siswa yang sudah masuk.
+            Silakan login terlebih dahulu untuk melanjutkan.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  const role: Role = isAdmin ? 'host' : 'viewer'
+
+  return (
+    <LiveRoom
+      key={role}
+      roomId={roomId}
+      role={role}
+      viewerName={studentSession?.fullName}
+    />
+  )
+}
+function LiveRoom({
+  roomId,
+  role,
+  viewerName
+}: {
+  roomId: string
+  role: Role
+  viewerName?: string
+}) {
+  const [clientId] = useState(() =>
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2)
+  )
+  const clientIdRef = useRef(clientId)
+  const wsRef = useRef<WebSocket | null>(null)
+  const peersRef = useRef<Map<string, RTCPeerConnection>>(new Map())
+  const remoteStreamsRef = useRef<Map<string, MediaStream>>(new Map())
+  const localStreamRef = useRef<MediaStream | null>(null)
+  const cameraStreamRef = useRef<MediaStream | null>(null)
+  const cameraVideoTrackRef = useRef<MediaStreamTrack | null>(null)
+  const screenStreamRef = useRef<MediaStream | null>(null)
+  const viewerPeerRef = useRef<RTCPeerConnection | null>(null)
+  const hostPeerIdRef = useRef<string | null>(null)
+
+  const [sessionId, setSessionId] = useState<string | null>(null)
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('idle')
+  const [statusMessage, setStatusMessage] = useState('Kelas belum dimulai')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isLive, setIsLive] = useState(false)
+  const [viewerCount, setViewerCount] = useState(0)
+  const [localPreviewStream, setLocalPreviewStream] = useState<MediaStream | null>(null)
+  const [remotePreviewStream, setRemotePreviewStream] = useState<MediaStream | null>(null)
+  const [recordingUrl, setRecordingUrl] = useState<string | null>(null)
+  const [isSharingScreen, setIsSharingScreen] = useState(false)
+
+  const localVideoRef = useRef<HTMLVideoElement | null>(null)
+  const remoteVideoRef = useRef<HTMLVideoElement | null>(null)
+
+  const iceServers = useMemo(resolveIceServers, [])
+
+  const {
+    startRecording,
+    stopRecording,
+    isRecording,
+    isProcessing: isProcessingRecording,
+    error: recorderError,
+    reset: resetRecorder
+  } = useRecorder()
+
+  useEffect(() => {
+    if (recorderError) {
+      setErrorMessage(recorderError)
+    }
+  }, [recorderError])
+
+  useEffect(() => {
+    if (localVideoRef.current && localPreviewStream) {
+      localVideoRef.current.srcObject = localPreviewStream
+    }
+  }, [localPreviewStream])
+
+  useEffect(() => {
+    if (remoteVideoRef.current && remotePreviewStream) {
+      remoteVideoRef.current.srcObject = remotePreviewStream
+    }
+  }, [remotePreviewStream])
+
+  const updateRemotePreview = useCallback(() => {
+    const streams = Array.from(remoteStreamsRef.current.values())
+    setRemotePreviewStream(streams[0] ?? null)
+  }, [])
+  const cleanupPeer = useCallback(
+    (peerId: string) => {
+      const peer = peersRef.current.get(peerId)
+      if (peer) {
+        try {
+          peer.onicecandidate = null
+          peer.ontrack = null
+          peer.onconnectionstatechange = null
+          peer.close()
+        } catch (error) {
+          console.warn('Failed to close peer connection', error)
+        }
+        peersRef.current.delete(peerId)
+      }
+      remoteStreamsRef.current.delete(peerId)
+      updateRemotePreview()
+    },
+    [updateRemotePreview]
+  )
+
+  const teardownConnections = useCallback(() => {
+    wsRef.current?.close()
+    wsRef.current = null
+
+    peersRef.current.forEach((_, peerId) => {
+      cleanupPeer(peerId)
+    })
+    peersRef.current.clear()
+
+    if (viewerPeerRef.current) {
+      try {
+        viewerPeerRef.current.ontrack = null
+        viewerPeerRef.current.onicecandidate = null
+        viewerPeerRef.current.onconnectionstatechange = null
+        viewerPeerRef.current.close()
+      } catch (error) {
+        console.warn('Failed to close viewer peer', error)
+      }
+      viewerPeerRef.current = null
+    }
+
+    remoteStreamsRef.current.clear()
+    setRemotePreviewStream(null)
+
+    if (screenStreamRef.current) {
+      screenStreamRef.current.getTracks().forEach((track) => track.stop())
+      screenStreamRef.current = null
+    }
+
+    if (localStreamRef.current) {
+      localStreamRef.current.getTracks().forEach((track) => track.stop())
+      localStreamRef.current = null
+    }
+
+    if (cameraStreamRef.current) {
+      cameraStreamRef.current.getTracks().forEach((track) => track.stop())
+      cameraStreamRef.current = null
+    }
+
+    cameraVideoTrackRef.current = null
+    setLocalPreviewStream(null)
+    setIsSharingScreen(false)
+    resetRecorder()
+  }, [cleanupPeer, resetRecorder])
+
+  useEffect(() => () => teardownConnections(), [teardownConnections])
+
+  const sendSignal = useCallback(
+    (payload: Record<string, unknown>) => {
+      const socket = wsRef.current
+      if (!socket || socket.readyState !== WebSocket.OPEN) {
+        return
+      }
+
+      socket.send(
+        JSON.stringify({
+          ...payload,
+          roomId,
+          clientId: clientIdRef.current
+        })
+      )
+    },
+    [roomId]
+  )
+  const handlePeerJoin = useCallback(
+    async (viewerId: string) => {
+      if (!localStreamRef.current) {
+        console.warn('No local stream available for new peer')
+        return
+      }
+
+      let peer = peersRef.current.get(viewerId)
+      if (!peer) {
+        peer = new RTCPeerConnection({ iceServers })
+        peersRef.current.set(viewerId, peer)
+
+        localStreamRef.current.getTracks().forEach((track) => {
+          peer?.addTrack(track, localStreamRef.current as MediaStream)
+        })
+
+        peer.onicecandidate = (event) => {
+          if (event.candidate) {
+            sendSignal({
+              type: 'ice',
+              target: viewerId,
+              candidate: event.candidate.toJSON()
+            })
+          }
+        }
+
+        peer.onconnectionstatechange = () => {
+          if (
+            peer &&
+            ['failed', 'disconnected', 'closed'].includes(peer.connectionState)
+          ) {
+            cleanupPeer(viewerId)
+          }
+        }
+
+        peer.ontrack = (event) => {
+          if (event.streams[0]) {
+            remoteStreamsRef.current.set(viewerId, event.streams[0])
+            updateRemotePreview()
+          }
+        }
+      }
+
+      try {
+        const offer = await peer.createOffer()
+        await peer.setLocalDescription(offer)
+        sendSignal({
+          type: 'offer',
+          target: viewerId,
+          sdp: offer.sdp
+        })
+      } catch (error) {
+        console.error('Failed to create/send offer', error)
+        setErrorMessage('Gagal mengirim offer kepada peserta')
+      }
+    },
+    [cleanupPeer, iceServers, sendSignal, updateRemotePreview]
+  )
+  const handleHostMessage = useCallback(
+    async (message: ServerMessage) => {
+      switch (message.type) {
+        case 'joined': {
+          setConnectionStatus('connected')
+          setStatusMessage('Siaran langsung siap. Undang siswa untuk bergabung.')
+          const viewerPeers = message.peers.filter(
+            (peer) => peer.clientId !== clientIdRef.current && peer.role === 'viewer'
+          )
+          setViewerCount(viewerPeers.length)
+          await Promise.all(viewerPeers.map((peer) => handlePeerJoin(peer.clientId)))
+          break
+        }
+        case 'peer-joined': {
+          if (message.role === 'viewer') {
+            setViewerCount((count) => count + 1)
+            setStatusMessage('Peserta baru bergabung ke kelas')
+            await handlePeerJoin(message.clientId)
+          }
+          break
+        }
+        case 'peer-left': {
+          cleanupPeer(message.clientId)
+          setViewerCount((count) => Math.max(0, count - 1))
+          setStatusMessage('Seorang peserta meninggalkan kelas')
+          break
+        }
+        case 'answer': {
+          const peer = peersRef.current.get(message.clientId)
+          if (!peer) {
+            console.warn('Peer not found for answer', message.clientId)
+            break
+          }
+          try {
+            await peer.setRemoteDescription(
+              new RTCSessionDescription({ type: 'answer', sdp: message.sdp })
+            )
+          } catch (error) {
+            console.error('Failed to set remote description (answer)', error)
+          }
+          break
+        }
+        case 'ice': {
+          const peer = peersRef.current.get(message.clientId)
+          if (!peer) {
+            break
+          }
+          try {
+            await peer.addIceCandidate(new RTCIceCandidate(message.candidate))
+          } catch (error) {
+            console.error('Failed to add ICE candidate', error)
+          }
+          break
+        }
+        case 'error': {
+          setErrorMessage(message.message)
+          break
+        }
+      }
+    },
+    [cleanupPeer, handlePeerJoin]
+  )
+  const handleViewerMessage = useCallback(
+    async (message: ServerMessage) => {
+      switch (message.type) {
+        case 'joined': {
+          setConnectionStatus('connected')
+          const viewers = message.peers.filter((peer) => peer.role === 'viewer')
+          setViewerCount(viewers.length)
+          const hostPeer = message.peers.find((peer) => peer.role === 'host')
+          hostPeerIdRef.current = hostPeer?.clientId ?? null
+          setStatusMessage(
+            hostPeer ? 'Menunggu stream dari guru...' : 'Guru belum bergabung ke kelas'
+          )
+          break
+        }
+        case 'offer': {
+          try {
+            hostPeerIdRef.current = message.clientId
+            let peer = viewerPeerRef.current
+            if (!peer) {
+              peer = new RTCPeerConnection({ iceServers })
+              viewerPeerRef.current = peer
+
+              peer.onicecandidate = (event) => {
+                if (event.candidate) {
+                  sendSignal({
+                    type: 'ice',
+                    target: message.clientId,
+                    candidate: event.candidate.toJSON()
+                  })
+                }
+              }
+
+              peer.ontrack = (event) => {
+                if (event.streams[0]) {
+                  setRemotePreviewStream(event.streams[0])
+                  setStatusMessage('Terhubung dengan guru')
+                }
+              }
+
+              peer.onconnectionstatechange = () => {
+                if (!viewerPeerRef.current) {
+                  return
+                }
+                if (
+                  ['failed', 'disconnected'].includes(viewerPeerRef.current.connectionState)
+                ) {
+                  setStatusMessage('Koneksi ke guru terputus. Mencoba kembali...')
+                }
+              }
+            }
+
+            await peer.setRemoteDescription(
+              new RTCSessionDescription({ type: 'offer', sdp: message.sdp })
+            )
+            const answer = await peer.createAnswer()
+            await peer.setLocalDescription(answer)
+            sendSignal({
+              type: 'answer',
+              target: message.clientId,
+              sdp: answer.sdp
+            })
+          } catch (error) {
+            console.error('Failed to handle offer', error)
+            setErrorMessage('Gagal menerima stream dari guru')
+          }
+          break
+        }
+        case 'ice': {
+          if (!viewerPeerRef.current) {
+            break
+          }
+          try {
+            await viewerPeerRef.current.addIceCandidate(
+              new RTCIceCandidate(message.candidate)
+            )
+          } catch (error) {
+            console.error('Failed to add ICE candidate (viewer)', error)
+          }
+          break
+        }
+        case 'peer-left': {
+          if (message.clientId === hostPeerIdRef.current) {
+            setStatusMessage('Guru keluar dari sesi. Menunggu untuk bergabung kembali...')
+            hostPeerIdRef.current = null
+            setRemotePreviewStream(null)
+            if (viewerPeerRef.current) {
+              try {
+                viewerPeerRef.current.ontrack = null
+                viewerPeerRef.current.onicecandidate = null
+                viewerPeerRef.current.onconnectionstatechange = null
+                viewerPeerRef.current.close()
+              } catch (error) {
+                console.warn('Failed to close viewer peer on host leave', error)
+              }
+              viewerPeerRef.current = null
+            }
+          }
+          if (message.clientId !== clientIdRef.current) {
+            setViewerCount((count) => Math.max(0, count - 1))
+          }
+          break
+        }
+        case 'peer-joined': {
+          if (message.role === 'viewer' && message.clientId !== clientIdRef.current) {
+            setViewerCount((count) => count + 1)
+          }
+          if (message.role === 'host') {
+            hostPeerIdRef.current = message.clientId
+            setStatusMessage('Guru bergabung, menunggu stream...')
+          }
+          break
+        }
+        case 'error': {
+          setErrorMessage(message.message)
+          break
+        }
+      }
+    },
+    [iceServers, sendSignal]
+  )
+  const connectWebSocket = useCallback(() => {
+    return new Promise<void>((resolve, reject) => {
+      if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+        resolve()
+        return
+      }
+
+      const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws'
+      const url = `${protocol}://${window.location.host}/api/ws`
+      const socket = new WebSocket(url)
+      wsRef.current = socket
+
+      socket.onopen = () => {
+        setConnectionStatus('connecting')
+        socket.send(
+          JSON.stringify({
+            type: 'join',
+            roomId,
+            clientId: clientIdRef.current,
+            role
+          })
+        )
+        resolve()
+      }
+
+      socket.onmessage = (event) => {
+        try {
+          const payload = JSON.parse(event.data) as ServerMessage
+          if (role === 'host') {
+            void handleHostMessage(payload)
+          } else {
+            void handleViewerMessage(payload)
+          }
+        } catch (error) {
+          console.error('Failed to parse signaling message', error)
+        }
+      }
+
+      socket.onerror = (event) => {
+        console.error('WebSocket error', event)
+        setConnectionStatus('error')
+        setErrorMessage('Koneksi signaling mengalami masalah')
+        reject(new Error('WebSocket error'))
+      }
+
+      socket.onclose = () => {
+        setConnectionStatus((current) => (current === 'connected' ? 'idle' : current))
+        if (role === 'host') {
+          setStatusMessage('Koneksi signaling ditutup')
+        } else {
+          setStatusMessage('Terputus dari server. Coba gabung ulang jika diperlukan.')
+        }
+      }
+    })
+  }, [handleHostMessage, handleViewerMessage, role, roomId])
+  const restoreCameraTrack = useCallback(() => {
+    if (!localStreamRef.current || !cameraVideoTrackRef.current) {
+      return
+    }
+
+    const localStream = localStreamRef.current
+    const videoTracks = localStream.getVideoTracks()
+    videoTracks.forEach((track) => {
+      localStream.removeTrack(track)
+      if (screenStreamRef.current) {
+        track.stop()
+      }
+    })
+
+    localStream.addTrack(cameraVideoTrackRef.current)
+    setLocalPreviewStream(new MediaStream(localStream.getTracks()))
+
+    peersRef.current.forEach((peer) => {
+      const sender = peer.getSenders().find((item) => item.track?.kind === 'video')
+      sender?.replaceTrack(cameraVideoTrackRef.current as MediaStreamTrack)
+    })
+
+    setIsSharingScreen(false)
+  }, [])
+
+  const stopShareScreen = useCallback(() => {
+    if (!isSharingScreen) {
+      return
+    }
+    if (screenStreamRef.current) {
+      screenStreamRef.current.getTracks().forEach((track) => track.stop())
+      screenStreamRef.current = null
+    }
+    restoreCameraTrack()
+  }, [isSharingScreen, restoreCameraTrack])
+
+  const handleToggleShareScreen = useCallback(async () => {
+    if (role !== 'host' || !localStreamRef.current) {
+      return
+    }
+
+    if (isSharingScreen) {
+      stopShareScreen()
+      return
+    }
+
+    try {
+      const displayStream = await navigator.mediaDevices.getDisplayMedia({
+        video: true,
+        audio: false
+      })
+      const screenTrack = displayStream.getVideoTracks()[0]
+      if (!screenTrack) {
+        setErrorMessage('Tidak dapat mengambil layar untuk dibagikan')
+        return
+      }
+
+      screenStreamRef.current = displayStream
+      screenTrack.onended = () => {
+        stopShareScreen()
+      }
+
+      const localStream = localStreamRef.current
+      localStream.getVideoTracks().forEach((track) => {
+        localStream.removeTrack(track)
+      })
+      localStream.addTrack(screenTrack)
+
+      setLocalPreviewStream(new MediaStream(localStream.getTracks()))
+      peersRef.current.forEach((peer) => {
+        const sender = peer.getSenders().find((item) => item.track?.kind === 'video')
+        sender?.replaceTrack(screenTrack)
+      })
+
+      setIsSharingScreen(true)
+      setStatusMessage('Berbagi layar ke peserta')
+    } catch (error) {
+      console.error('Failed to start screen share', error)
+      setErrorMessage('Gagal memulai share screen')
+    }
+  }, [isSharingScreen, role, stopShareScreen])
+  const initializeLocalStream = useCallback(async () => {
+    setStatusMessage('Meminta izin kamera & mikrofon...')
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true })
+    cameraStreamRef.current = stream
+    cameraVideoTrackRef.current = stream.getVideoTracks()[0] ?? null
+    localStreamRef.current = stream
+    setLocalPreviewStream(new MediaStream(stream.getTracks()))
+  }, [])
+
+  const handleStartClass = useCallback(async () => {
+    if (role !== 'host' || isLive) {
+      return
+    }
+
+    try {
+      setErrorMessage(null)
+      setConnectionStatus('initializing')
+      await initializeLocalStream()
+
+      setStatusMessage('Mempersiapkan sesi live...')
+      const startResponse = await fetch(`/api/classroom/${roomId}/session/start`, {
+        method: 'POST'
+      })
+
+      if (!startResponse.ok) {
+        throw new Error('Gagal membuat sesi live')
+      }
+
+      const payload = (await startResponse.json()) as { session: { id: string } }
+      setSessionId(payload.session.id)
+
+      await connectWebSocket()
+      setIsLive(true)
+      setStatusMessage('Siaran dimulai. Siswa dapat bergabung sekarang.')
+    } catch (error) {
+      console.error('Failed to start class', error)
+      setConnectionStatus('error')
+      setErrorMessage(
+        error instanceof Error ? error.message : 'Gagal memulai kelas langsung'
+      )
+      teardownConnections()
+      setIsLive(false)
+      setSessionId(null)
+    }
+  }, [connectWebSocket, initializeLocalStream, isLive, role, roomId, teardownConnections])
+
+  const finalizeSession = useCallback(
+    async (recordUrl?: string | null) => {
+      if (!sessionId) {
+        return
+      }
+
+      try {
+        await fetch(`/api/classroom/${roomId}/session/end`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessionId,
+            recordingUrl: recordUrl ?? recordingUrl ?? null
+          })
+        })
+      } catch (error) {
+        console.error('Failed to finalize session', error)
+        setErrorMessage('Sesi berakhir, tetapi gagal menyimpan status ke server')
+      }
+    },
+    [recordingUrl, roomId, sessionId]
+  )
+
+  const handleStopRecording = useCallback(async () => {
+    if (role !== 'host' || !isRecording) {
+      return
+    }
+
+    try {
+      const blob = await stopRecording()
+      if (blob) {
+        setStatusMessage('Mengunggah rekaman ke Cloudinary...')
+        const upload = await uploadRecordingToCloudinary(blob, {
+          folder: `gema-classroom/${roomId}`,
+          fileName: `classroom-${roomId}-${Date.now()}.webm`
+        })
+        setRecordingUrl(upload.secureUrl)
+        setStatusMessage('Rekaman berhasil disimpan')
+      }
+    } catch (error) {
+      console.error('Failed to stop recording', error)
+      setErrorMessage('Gagal menyimpan rekaman')
+    }
+  }, [isRecording, role, roomId, stopRecording])
+  const handleEndClass = useCallback(async () => {
+    if (role !== 'host' || !isLive) {
+      return
+    }
+
+    try {
+      setStatusMessage('Mengakhiri sesi live...')
+      if (isRecording) {
+        await handleStopRecording()
+      }
+      await finalizeSession()
+    } finally {
+      teardownConnections()
+      setIsLive(false)
+      setViewerCount(0)
+      setSessionId(null)
+      setConnectionStatus('idle')
+      setStatusMessage('Kelas telah diakhiri')
+    }
+  }, [finalizeSession, handleStopRecording, isLive, isRecording, role, teardownConnections])
+  const handleStartRecording = useCallback(async () => {
+    if (role !== 'host' || !localStreamRef.current || isRecording) {
+      return
+    }
+
+    try {
+      await startRecording(localStreamRef.current)
+      setStatusMessage('Perekaman dimulai')
+      setErrorMessage(null)
+    } catch (error) {
+      console.error('Failed to start recording', error)
+      setErrorMessage('Gagal memulai perekaman')
+    }
+  }, [isRecording, role, startRecording])
+  const handleJoinClass = useCallback(async () => {
+    if (role !== 'viewer') {
+      return
+    }
+
+    try {
+      setErrorMessage(null)
+      setStatusMessage('Menghubungkan ke kelas...')
+      await connectWebSocket()
+    } catch (error) {
+      console.error('Failed to join class', error)
+      setErrorMessage('Tidak dapat terhubung ke sesi live')
+    }
+  }, [connectWebSocket, role])
+  const statusLabel = useMemo(() => {
+    switch (connectionStatus) {
+      case 'initializing':
+        return 'Menyiapkan...'
+      case 'connecting':
+        return 'Menghubungkan'
+      case 'connected':
+        return 'Terhubung'
+      case 'error':
+        return 'Kesalahan'
+      default:
+        return 'Idle'
+    }
+  }, [connectionStatus])
+
+  const statusClass = useMemo(() => {
+    switch (connectionStatus) {
+      case 'connected':
+        return 'bg-emerald-500/10 text-emerald-300 border border-emerald-500/40'
+      case 'connecting':
+      case 'initializing':
+        return 'bg-amber-500/10 text-amber-300 border border-amber-500/40'
+      case 'error':
+        return 'bg-red-500/10 text-red-300 border border-red-500/40'
+      default:
+        return 'bg-slate-700/40 text-slate-300 border border-slate-600/60'
+    }
+  }, [connectionStatus])
+  return (
+    <div className="min-h-screen bg-slate-950 text-white">
+      <div className="mx-auto flex max-w-6xl flex-col gap-8 px-4 py-10">
+        <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <div className="flex items-center gap-3 text-sm text-slate-300">
+              <Video className="h-5 w-5 text-sky-400" />
+              <span>Classroom ID: {roomId}</span>
+            </div>
+            <h1 className="mt-2 flex items-center gap-3 text-3xl font-semibold">
+              Live Classroom
+              <span className="rounded-full bg-sky-500/10 px-3 py-1 text-sm font-medium text-sky-300">
+                {role === 'host' ? 'Mode Guru' : 'Mode Siswa'}
+              </span>
+            </h1>
+            <p className="mt-1 text-slate-300">
+              {role === 'host'
+                ? 'Mulai siaran langsung dan hubungkan siswa secara real-time.'
+                : viewerName
+                ? `Halo ${viewerName}, klik "Join Class" untuk mulai menonton.`
+                : 'Klik "Join Class" untuk mulai menonton siaran guru secara langsung.'}
+            </p>
+          </div>
+          <div className={`flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium ${statusClass}`}>
+            <Monitor className="h-4 w-4" />
+            <span>{statusLabel}</span>
+          </div>
+        </header>
+
+        <div className="grid gap-6 lg:grid-cols-3">
+          <div className="space-y-6 lg:col-span-2">
+            {role === 'host' ? (
+              <div className="space-y-6">
+                <VideoPreview
+                  ref={localVideoRef}
+                  stream={localPreviewStream}
+                  muted
+                  label="Preview Guru"
+                  placeholder="Mulai kelas untuk melihat pratinjau kamera"
+                />
+                <VideoPreview
+                  ref={remoteVideoRef}
+                  stream={remotePreviewStream}
+                  label="Preview Peserta"
+                  placeholder="Peserta akan muncul di sini ketika terhubung"
+                />
+              </div>
+            ) : (
+              <VideoPreview
+                ref={remoteVideoRef}
+                stream={remotePreviewStream}
+                label="Live dari Guru"
+                placeholder="Menunggu guru memulai siaran"
+              />
+            )}
+
+            <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+              <div className="flex items-center gap-3 text-slate-300">
+                <Users className="h-5 w-5 text-sky-400" />
+                <span className="text-sm">Viewer saat ini: {viewerCount}</span>
+              </div>
+              <p className="mt-4 text-sm text-slate-300">{statusMessage}</p>
+              {errorMessage && (
+                <div className="mt-4 flex items-center gap-3 rounded-lg border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-200">
+                  <AlertCircle className="h-5 w-5" />
+                  <span>{errorMessage}</span>
+                </div>
+              )}
+              {recordingUrl && (
+                <div className="mt-4 flex items-center gap-3 rounded-lg border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-200">
+                  <CheckCircle2 className="h-5 w-5" />
+                  <a
+                    href={recordingUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline"
+                  >
+                    Rekaman tersedia di Cloudinary
+                  </a>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <aside className="space-y-6">
+            <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6">
+              <h2 className="text-lg font-semibold">Kontrol</h2>
+              <div className="mt-4 flex flex-col gap-3">
+                {role === 'host' ? (
+                  <>
+                    <button
+                      onClick={handleStartClass}
+                      disabled={isLive || connectionStatus === 'initializing'}
+                      className="flex items-center justify-center gap-2 rounded-lg bg-sky-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-slate-600"
+                    >
+                      <Play className="h-4 w-4" /> Mulai Kelas
+                    </button>
+                    <button
+                      onClick={handleEndClass}
+                      disabled={!isLive}
+                      className="flex items-center justify-center gap-2 rounded-lg bg-red-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-400 disabled:cursor-not-allowed disabled:bg-slate-600"
+                    >
+                      <Square className="h-4 w-4" /> Akhiri Kelas
+                    </button>
+                    <button
+                      onClick={handleToggleShareScreen}
+                      disabled={!isLive}
+                      className="flex items-center justify-center gap-2 rounded-lg bg-purple-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-purple-400 disabled:cursor-not-allowed disabled:bg-slate-600"
+                    >
+                      {isSharingScreen ? (
+                        <>
+                          <ScreenShareOff className="h-4 w-4" /> Berhenti Bagikan Layar
+                        </>
+                      ) : (
+                        <>
+                          <ScreenShare className="h-4 w-4" /> Bagikan Layar
+                        </>
+                      )}
+                    </button>
+                    <button
+                      onClick={handleStartRecording}
+                      disabled={!isLive || isRecording || isProcessingRecording}
+                      className="flex items-center justify-center gap-2 rounded-lg bg-emerald-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-slate-600"
+                    >
+                      <UploadCloud className="h-4 w-4" /> Mulai Rekam
+                    </button>
+                    <button
+                      onClick={handleStopRecording}
+                      disabled={!isRecording}
+                      className="flex items-center justify-center gap-2 rounded-lg bg-amber-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-amber-400 disabled:cursor-not-allowed disabled:bg-slate-600"
+                    >
+                      <Square className="h-4 w-4" /> Simpan Rekaman
+                    </button>
+                    {isProcessingRecording && (
+                      <div className="flex items-center gap-2 text-sm text-slate-300">
+                        <Loader2 className="h-4 w-4 animate-spin" /> Memproses rekaman...
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <button
+                    onClick={handleJoinClass}
+                    disabled={connectionStatus === 'connecting' || connectionStatus === 'connected'}
+                    className="flex items-center justify-center gap-2 rounded-lg bg-sky-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:bg-slate-600"
+                  >
+                    {connectionStatus === 'connecting' ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Play className="h-4 w-4" />
+                    )}
+                    {connectionStatus === 'connected' ? 'Sudah Terhubung' : 'Join Class'}
+                  </button>
+                )}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-sm text-slate-300">
+              <h3 className="text-base font-semibold text-white">Catatan</h3>
+              <ul className="mt-3 list-disc space-y-2 pl-5">
+                <li>Gunakan headphone untuk menghindari feedback audio.</li>
+                <li>Stabilkan koneksi internet sebelum memulai siaran.</li>
+                <li>Rekaman akan otomatis diunggah setelah tombol simpan ditekan.</li>
+              </ul>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const VideoPreview = forwardRef<HTMLVideoElement, VideoPreviewProps>(
+  ({ stream, muted, label, placeholder }, ref) => {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between text-sm text-slate-300">
+          <span className="font-medium text-white">{label}</span>
+          {stream ? (
+            <span className="flex items-center gap-2 text-emerald-300">
+              <CheckCircle2 className="h-4 w-4" /> Aktif
+            </span>
+          ) : (
+            <span className="text-slate-400">Menunggu sinyal...</span>
+          )}
+        </div>
+        <div className="relative overflow-hidden rounded-2xl border border-slate-800 bg-black/60">
+          <video
+            ref={ref}
+            className="aspect-video w-full bg-black"
+            playsInline
+            autoPlay
+            muted={muted ?? false}
+          />
+          {!stream && (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-slate-400">
+              <Video className="h-10 w-10 text-slate-500" />
+              <p className="text-center text-sm">{placeholder ?? 'Menunggu stream tersedia'}</p>
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+)
+
+VideoPreview.displayName = 'VideoPreview'
+

--- a/src/hooks/useRecorder.ts
+++ b/src/hooks/useRecorder.ts
@@ -1,0 +1,123 @@
+'use client'
+
+import { useCallback, useRef, useState } from 'react'
+
+type UseRecorderOptions = {
+  mimeType?: string
+}
+
+type UseRecorderResult = {
+  isRecording: boolean
+  isProcessing: boolean
+  error: string | null
+  startRecording: (stream: MediaStream) => Promise<void>
+  stopRecording: () => Promise<Blob | null>
+  reset: () => void
+}
+
+export function useRecorder(options: UseRecorderOptions = {}): UseRecorderResult {
+  const mimeType = options.mimeType ?? 'video/webm;codecs=vp9,opus'
+  const recorderRef = useRef<MediaRecorder | null>(null)
+  const chunksRef = useRef<Blob[]>([])
+  const [isRecording, setIsRecording] = useState(false)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const reset = useCallback(() => {
+    setIsRecording(false)
+    setIsProcessing(false)
+    setError(null)
+    chunksRef.current = []
+    if (recorderRef.current) {
+      recorderRef.current.ondataavailable = null
+      recorderRef.current.onstop = null
+      recorderRef.current.onerror = null
+      recorderRef.current = null
+    }
+  }, [])
+
+  const startRecording = useCallback(
+    async (stream: MediaStream) => {
+      if (typeof window === 'undefined') return
+
+      if (!stream) {
+        setError('Stream is not available for recording')
+        return
+      }
+
+      if (isRecording) {
+        setError('Recorder is already running')
+        return
+      }
+
+      try {
+        const recorder = new MediaRecorder(stream, { mimeType })
+        chunksRef.current = []
+
+        recorder.ondataavailable = (event) => {
+          if (event.data && event.data.size > 0) {
+            chunksRef.current.push(event.data)
+          }
+        }
+
+        recorder.onerror = (event) => {
+          console.error('MediaRecorder error', event)
+          setError('Recording error occurred')
+        }
+
+        recorder.onstop = () => {
+          setIsRecording(false)
+          setIsProcessing(false)
+        }
+
+        recorder.start(2000)
+        recorderRef.current = recorder
+        setIsRecording(true)
+        setError(null)
+      } catch (err) {
+        console.error('Failed to start recorder', err)
+        setError('Tidak dapat memulai perekaman')
+        reset()
+      }
+    },
+    [isRecording, mimeType, reset]
+  )
+
+  const stopRecording = useCallback(async () => {
+    if (!recorderRef.current) {
+      setError('Recorder is not active')
+      return null
+    }
+
+    return new Promise<Blob | null>((resolve) => {
+      try {
+        setIsProcessing(true)
+        recorderRef.current!.onstop = () => {
+          setIsRecording(false)
+          setIsProcessing(false)
+          const blob = chunksRef.current.length
+            ? new Blob(chunksRef.current, { type: mimeType })
+            : null
+          resolve(blob)
+          chunksRef.current = []
+          recorderRef.current = null
+        }
+
+        recorderRef.current!.stop()
+      } catch (err) {
+        console.error('Failed to stop recorder', err)
+        setError('Gagal menghentikan perekaman')
+        resolve(null)
+      }
+    })
+  }, [mimeType])
+
+  return {
+    isRecording,
+    isProcessing,
+    error,
+    startRecording,
+    stopRecording,
+    reset
+  }
+}

--- a/src/lib/cloudinaryUpload.ts
+++ b/src/lib/cloudinaryUpload.ts
@@ -1,0 +1,83 @@
+'use client'
+
+interface SignedUploadParams {
+  timestamp: number
+  signature: string
+  apiKey: string
+  cloudName: string
+  folder?: string
+  publicId?: string
+}
+
+interface SignRequestBody {
+  folder?: string
+  publicId?: string
+  resourceType?: 'video' | 'auto' | 'raw'
+}
+
+interface UploadOptions extends SignRequestBody {
+  fileName?: string
+}
+
+interface UploadResult {
+  secureUrl: string
+  publicId?: string
+}
+
+const CLOUDINARY_UPLOAD_ENDPOINT = '/api/upload'
+
+async function getSignedParams(body: SignRequestBody = {}): Promise<SignedUploadParams> {
+  const response = await fetch(CLOUDINARY_UPLOAD_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  })
+
+  if (!response.ok) {
+    throw new Error('Failed to get Cloudinary signature')
+  }
+
+  return (await response.json()) as SignedUploadParams
+}
+
+export async function uploadRecordingToCloudinary(file: Blob, options: UploadOptions = {}): Promise<UploadResult> {
+  const { folder, publicId, resourceType = 'video', fileName } = options
+  const signedParams = await getSignedParams({ folder, publicId, resourceType })
+
+  const uploadUrl = `https://api.cloudinary.com/v1_1/${signedParams.cloudName}/${resourceType}/upload`
+  const formData = new FormData()
+
+  formData.append('file', file, fileName ?? `recording-${Date.now()}.webm`)
+  formData.append('api_key', signedParams.apiKey)
+  formData.append('timestamp', String(signedParams.timestamp))
+  formData.append('signature', signedParams.signature)
+
+  if (folder) {
+    formData.append('folder', folder)
+  }
+
+  if (publicId) {
+    formData.append('public_id', publicId)
+  }
+
+  const uploadResponse = await fetch(uploadUrl, {
+    method: 'POST',
+    body: formData
+  })
+
+  if (!uploadResponse.ok) {
+    const errorText = await uploadResponse.text()
+    console.error('Cloudinary upload failed', errorText)
+    throw new Error('Cloudinary upload failed')
+  }
+
+  const payload = (await uploadResponse.json()) as {
+    secure_url: string
+    public_id?: string
+  }
+
+  return {
+    secureUrl: payload.secure_url,
+    publicId: payload.public_id
+  }
+}


### PR DESCRIPTION
## Summary
- update the classroom session start/end API routes to derive the classroom id from the request URL so the edge runtime types pass Next.js validation
- adjust the edge WebSocket handler typings for WebSocketPair/accept to satisfy Next.js build checks
- reorder the live classroom page recording handlers to avoid use-before-declaration during compilation

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df698ce0e08326945e1efb39798e63