### PR TITLE
Ensure Prisma client generated before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
+    "prebuild": "prisma generate",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -353,6 +353,7 @@ model Classroom {
 
   liveSessions LiveSession[]
 
+  @@index([teacherId])
   @@map("classrooms")
 }
 

--- a/prisma/seed-classroom.ts
+++ b/prisma/seed-classroom.ts
@@ -2,38 +2,45 @@ import { PrismaClient } from '@prisma/client'
 
 const prisma = new PrismaClient()
 
+const CLASSROOMS = [
+  {
+    id: 'gema-classroom-1',
+    title: 'GEMA - Generasi Muda Informatika',
+    slug: 'gema-classroom-1',
+    description:
+      'Kelas ekstrakulikuler informatika SMA Wahidiyah Kediri. Belajar web development, programming, dan teknologi terkini.',
+    teacherId: 'admin-gema-001'
+  },
+  {
+    id: 'gema-advanced-1',
+    title: 'GEMA Advanced - Full Stack Development',
+    slug: 'gema-advanced-1',
+    description:
+      'Kelas lanjutan untuk siswa yang ingin mendalami full stack web development dengan React, Node.js, dan database.',
+    teacherId: 'admin-gema-001'
+  }
+]
+
+async function upsertClassroom(classroom: (typeof CLASSROOMS)[number]) {
+  return prisma.classroom.upsert({
+    where: { id: classroom.id },
+    update: {
+      title: classroom.title,
+      slug: classroom.slug,
+      description: classroom.description,
+      teacherId: classroom.teacherId
+    },
+    create: classroom
+  })
+}
+
 async function main() {
   console.log('🏫 Seeding Classroom data...')
 
-  // Create default classroom for GEMA
-  const classroom = await prisma.classroom.upsert({
-    where: { id: 'gema-classroom-1' },
-    update: {},
-    create: {
-      id: 'gema-classroom-1',
-      title: 'GEMA - Generasi Muda Informatika',
-      slug: 'gema-classroom-1',
-      description: 'Kelas ekstrakulikuler informatika SMA Wahidiyah Kediri. Belajar web development, programming, dan teknologi terkini.',
-      teacherId: 'admin-gema-001'
-    }
-  })
-
-  console.log('✅ Classroom created:', classroom)
-
-  // Create additional classrooms
-  const advancedClassroom = await prisma.classroom.upsert({
-    where: { id: 'gema-advanced-1' },
-    update: {},
-    create: {
-      id: 'gema-advanced-1',
-      title: 'GEMA Advanced - Full Stack Development',
-      slug: 'gema-advanced-1',
-      description: 'Kelas lanjutan untuk siswa yang ingin mendalami full stack web development dengan React, Node.js, dan database.',
-      teacherId: 'admin-gema-001'
-    }
-  })
-
-  console.log('✅ Advanced Classroom created:', advancedClassroom)
+  for (const classroom of CLASSROOMS) {
+    const seeded = await upsertClassroom(classroom)
+    console.log(`✅ Classroom ready: ${seeded.id} – ${seeded.title}`)
+  }
 
   console.log('🎉 Classroom seeding completed!')
 }
@@ -42,8 +49,8 @@ main()
   .then(async () => {
     await prisma.$disconnect()
   })
-  .catch(async (e) => {
-    console.error('❌ Error seeding classroom:', e)
+  .catch(async (error) => {
+    console.error('❌ Error seeding classroom:', error)
     await prisma.$disconnect()
     process.exit(1)
   })


### PR DESCRIPTION
## Summary
- run `prisma generate` automatically before every `next build` so Prisma Client always exposes the classroom delegate
- streamline the classroom seed script with a typed helper that sequentially upserts the default classrooms and ensures the client disconnects on completion or failure

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0c15f5cc083269b625347ed33d43e