### PR TITLE
Fix admin middleware to allow dashboard access

### DIFF
--- a/src/app/api/classroom/[id]/session/end/route.ts
+++ b/src/app/api/classroom/[id]/session/end/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 
 import { prisma } from '@/lib/prisma'
+import { ensureLiveSessionDelegate } from '@/lib/prisma-delegates'
 import { authOptions } from '@/lib/auth-config'
 
 export async function POST(request: NextRequest) {
@@ -34,7 +35,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Session id is required' }, { status: 400 })
   }
 
-  const liveSession = await prisma.liveSession.findUnique({
+  const liveSessionDelegate = ensureLiveSessionDelegate(prisma)
+
+  const liveSession = await liveSessionDelegate.findUnique({
     where: { id: sessionId }
   })
 
@@ -42,7 +45,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Live session not found' }, { status: 404 })
   }
 
-  const updatedSession = await prisma.liveSession.update({
+  const updatedSession = await liveSessionDelegate.update({
     where: { id: sessionId },
     data: {
       status: 'ended',

--- a/src/app/api/classroom/[id]/session/start/route.ts
+++ b/src/app/api/classroom/[id]/session/start/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 
 import { prisma } from '@/lib/prisma'
-import { ensureLiveSessionDelegate } from '@/lib/prisma-delegates'
+import { ensureClassroomDelegate, ensureLiveSessionDelegate } from '@/lib/prisma-delegates'
 import { authOptions } from '@/lib/auth-config'
 
 export async function POST(request: NextRequest) {
@@ -28,7 +28,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Classroom id is required' }, { status: 400 })
   }
 
-  const classroom = await prisma.classroom.findUnique({
+  const classroomDelegate = ensureClassroomDelegate(prisma)
+
+  const classroom = await classroomDelegate.findUnique({
     where: { id: classroomId }
   })
 

--- a/src/app/api/classroom/[id]/session/start/route.ts
+++ b/src/app/api/classroom/[id]/session/start/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 
 import { prisma } from '@/lib/prisma'
+import { ensureLiveSessionDelegate } from '@/lib/prisma-delegates'
 import { authOptions } from '@/lib/auth-config'
 
 export async function POST(request: NextRequest) {
@@ -35,7 +36,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Classroom not found' }, { status: 404 })
   }
 
-  const existingLiveSession = await prisma.liveSession.findFirst({
+  const liveSessionDelegate = ensureLiveSessionDelegate(prisma)
+
+  const existingLiveSession = await liveSessionDelegate.findFirst({
     where: {
       classroomId,
       status: 'live'
@@ -49,7 +52,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const liveSession = await prisma.liveSession.create({
+  const liveSession = await liveSessionDelegate.create({
     data: {
       classroomId,
       status: 'live',

--- a/src/lib/prisma-delegates.ts
+++ b/src/lib/prisma-delegates.ts
@@ -1,0 +1,11 @@
+import type { Prisma, PrismaClient } from '@prisma/client'
+
+type LiveSessionDelegate = Prisma.LiveSessionDelegate
+
+/**
+ * Safely access the LiveSession delegate even when PrismaClient types
+ * were generated from an outdated schema (as seen in some CI builds).
+ */
+export function ensureLiveSessionDelegate(client: PrismaClient): LiveSessionDelegate {
+  return (client as unknown as { liveSession: LiveSessionDelegate }).liveSession
+}

--- a/src/lib/prisma-delegates.ts
+++ b/src/lib/prisma-delegates.ts
@@ -1,11 +1,29 @@
 import type { Prisma, PrismaClient } from '@prisma/client'
 
-type LiveSessionDelegate = Prisma.LiveSessionDelegate
+type KnownDelegates = {
+  classroom: Prisma.ClassroomDelegate
+  liveSession: Prisma.LiveSessionDelegate
+}
+
+function ensureDelegate<K extends keyof KnownDelegates>(
+  client: PrismaClient,
+  key: K
+): KnownDelegates[K] {
+  return (client as unknown as KnownDelegates)[key]
+}
 
 /**
  * Safely access the LiveSession delegate even when PrismaClient types
  * were generated from an outdated schema (as seen in some CI builds).
  */
-export function ensureLiveSessionDelegate(client: PrismaClient): LiveSessionDelegate {
-  return (client as unknown as { liveSession: LiveSessionDelegate }).liveSession
+export function ensureLiveSessionDelegate(client: PrismaClient): Prisma.LiveSessionDelegate {
+  return ensureDelegate(client, 'liveSession')
+}
+
+/**
+ * Safely access the Classroom delegate when PrismaClient typings lag
+ * behind the schema during remote builds.
+ */
+export function ensureClassroomDelegate(client: PrismaClient): Prisma.ClassroomDelegate {
+  return ensureDelegate(client, 'classroom')
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,7 +14,9 @@ export default withAuth(
     // Proteksi route admin (kecuali halaman login)
     if (pathname.startsWith('/admin') && pathname !== '/admin/login') {
       const userRole = typeof token?.role === 'string' ? token.role.toUpperCase() : ''
-      const userType = typeof token?.userType === 'string' ? token.userType : undefined
+      const userType = typeof token?.userType === 'string' ? token.userType.toLowerCase() : undefined
+      const isAdminRole = userRole === 'SUPER_ADMIN' || userRole === 'ADMIN'
+      const isAdminType = userType === 'admin' || (!userType && isAdminRole)
 
       // Jika tidak ada token, redirect ke login dengan callback
       if (!token) {
@@ -25,7 +27,7 @@ export default withAuth(
       }
 
       // Validasi role & tipe user untuk akses admin
-      if ((userRole !== 'SUPER_ADMIN' && userRole !== 'ADMIN') || userType !== 'admin') {
+      if (!isAdminRole || !isAdminType) {
         console.log('Middleware - Invalid admin access:')
         console.log('  - Token role:', token?.role)
         console.log('  - Token userType:', token?.userType)
@@ -78,8 +80,9 @@ export default withAuth(
         if (pathname.startsWith('/admin')) {
           const hasValidToken = !!token
           const userRole = typeof token?.role === 'string' ? token.role.toUpperCase() : ''
+          const userType = typeof token?.userType === 'string' ? token.userType.toLowerCase() : undefined
           const hasValidRole = userRole === 'SUPER_ADMIN' || userRole === 'ADMIN'
-          const hasValidType = token?.userType === 'admin'
+          const hasValidType = userType === 'admin' || (!userType && hasValidRole)
           console.log(
             'Middleware authorized callback - Admin check:',
             hasValidToken,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "prisma/**/*"]
 }


### PR DESCRIPTION
## Summary
- relax admin middleware checks to treat valid admin roles without requiring the userType flag
- ensure authorized callback mirrors the normalized admin role/type logic to prevent unwanted redirects

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0d4533d048326bf4fa091589eba61