### PR TITLE
Refactor live classroom signaling into utilities

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,18 @@ const eslintConfig = [
       "next-env.d.ts",
     ],
   },
+  {
+    files: [
+      "*.js",
+      "*.cjs",
+      "*.mjs",
+      "scripts/**/*.js",
+      "tests/**/*.js",
+    ],
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/src/app/classroom/[id]/live/utils/debug.ts
+++ b/src/app/classroom/[id]/live/utils/debug.ts
@@ -1,0 +1,75 @@
+const GLOBAL_DEBUG_FLAG = 'debug:live-classroom'
+const ENV_DEBUG_FLAG = process.env.NEXT_PUBLIC_DEBUG_LIVE_CLASSROOM
+
+function isDebugEnabled(): boolean {
+  if (ENV_DEBUG_FLAG) {
+    return ENV_DEBUG_FLAG === 'true' || ENV_DEBUG_FLAG === '1'
+  }
+
+  if (typeof window !== 'undefined') {
+    try {
+      const stored = window.localStorage.getItem(GLOBAL_DEBUG_FLAG)
+      if (stored !== null) {
+        return stored === 'true'
+      }
+    } catch (error) {
+      console.warn('[LiveClassroom:debug] Failed to access localStorage', error)
+    }
+  }
+
+  return process.env.NODE_ENV !== 'production'
+}
+
+export type DebugLogger = {
+  log: (...args: unknown[]) => void
+  info: (...args: unknown[]) => void
+  warn: (...args: unknown[]) => void
+  error: (...args: unknown[]) => void
+  time: (label: string) => void
+  timeEnd: (label: string) => void
+}
+
+export function createDebugLogger(namespace: string): DebugLogger {
+  const prefix = `[LiveClassroom:${namespace}]`
+
+  const emit = (level: 'log' | 'info' | 'warn' | 'error', args: unknown[]) => {
+    const shouldEmit = level === 'error' ? true : isDebugEnabled()
+    if (!shouldEmit) {
+      return
+    }
+
+    const consoleMethod = console[level] ?? console.log
+    consoleMethod(prefix, ...args)
+  }
+
+  const timers = new Set<string>()
+
+  return {
+    log: (...args: unknown[]) => emit('log', args),
+    info: (...args: unknown[]) => emit('info', args),
+    warn: (...args: unknown[]) => emit('warn', args),
+    error: (...args: unknown[]) => emit('error', args),
+    time: (label: string) => {
+      if (!isDebugEnabled()) return
+      if (timers.has(label)) return
+      timers.add(label)
+      console.time(`${prefix} ${label}`)
+    },
+    timeEnd: (label: string) => {
+      if (!isDebugEnabled()) return
+      if (!timers.has(label)) return
+      timers.delete(label)
+      console.timeEnd(`${prefix} ${label}`)
+    }
+  }
+}
+
+export function toggleDebugLogging(enabled: boolean): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(GLOBAL_DEBUG_FLAG, enabled ? 'true' : 'false')
+    console.log('[LiveClassroom:debug] Logging updated', { enabled })
+  } catch (error) {
+    console.warn('[LiveClassroom:debug] Failed to update debug flag', error)
+  }
+}

--- a/src/app/classroom/[id]/live/utils/iceServers.ts
+++ b/src/app/classroom/[id]/live/utils/iceServers.ts
@@ -1,0 +1,91 @@
+import { createDebugLogger } from './debug'
+
+const FALLBACK_STUN = [
+  'stun:stun.l.google.com:19302',
+  'stun:stun1.l.google.com:19302',
+  'stun:stun2.l.google.com:19302',
+  'stun:stun3.l.google.com:19302'
+]
+
+const iceLog = createDebugLogger('ice')
+
+let cachedIceServers: RTCIceServer[] | null = null
+
+export function sanitizeStunEnv(rawValue: string): string {
+  const trimmed = rawValue.trim()
+  if (!trimmed.length) return trimmed
+  const withoutWrappingQuotes = trimmed.replace(/^['"]|['"]$/g, '')
+  return withoutWrappingQuotes
+}
+
+function normalizeStunConfig(rawValue: string): string[] {
+  const sanitized = sanitizeStunEnv(rawValue)
+  if (!sanitized) {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(sanitized)
+    const entries = Array.isArray(parsed) ? parsed : [parsed]
+    return entries
+      .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+      .filter((entry) => entry.length > 0)
+  } catch (jsonError) {
+    iceLog.warn('Failed to parse STUN config as JSON, attempting comma split', {
+      error: jsonError,
+      value: sanitized
+    })
+    return sanitized
+      .split(',')
+      .map((segment) => segment.trim())
+      .filter((segment) => segment.length > 0)
+  }
+}
+
+export function resolveIceServers(): RTCIceServer[] {
+  if (cachedIceServers) {
+    return cachedIceServers.map((server) => ({ ...server }))
+  }
+
+  const servers: RTCIceServer[] = []
+  const stunEnvRaw = process.env.NEXT_PUBLIC_STUN_URLS
+  const resolvedStunUrls: string[] = []
+
+  if (stunEnvRaw) {
+    const candidateStun = normalizeStunConfig(stunEnvRaw)
+    if (candidateStun.length) {
+      resolvedStunUrls.push(...candidateStun)
+      iceLog.info('Using STUN servers from environment', candidateStun)
+    }
+  }
+
+  if (!resolvedStunUrls.length) {
+    resolvedStunUrls.push(...FALLBACK_STUN)
+    iceLog.info('Falling back to default STUN servers', FALLBACK_STUN)
+  }
+
+  servers.push({ urls: resolvedStunUrls })
+
+  const turnUrl = process.env.NEXT_PUBLIC_TURN_URL
+  const turnUsername = process.env.NEXT_PUBLIC_TURN_USERNAME
+  const turnPassword = process.env.NEXT_PUBLIC_TURN_PASSWORD
+
+  if (turnUrl && turnUsername && turnPassword) {
+    iceLog.info('TURN configuration detected')
+    servers.push({
+      urls: turnUrl,
+      username: turnUsername,
+      credential: turnPassword
+    })
+  } else if (turnUrl || turnUsername || turnPassword) {
+    iceLog.warn('Incomplete TURN configuration detected, ignoring credentials', {
+      turnUrl,
+      hasUsername: Boolean(turnUsername),
+      hasPassword: Boolean(turnPassword)
+    })
+  }
+
+  cachedIceServers = servers.map((server) => ({ ...server }))
+  iceLog.info('Resolved ICE servers', cachedIceServers)
+  return cachedIceServers.map((server) => ({ ...server }))
+}

--- a/src/app/classroom/[id]/live/utils/signaling.ts
+++ b/src/app/classroom/[id]/live/utils/signaling.ts
@@ -1,0 +1,159 @@
+import { createDebugLogger } from './debug'
+import { Role, SignalingServerMessage, isSignalingServerMessage } from './types'
+
+const signalingLog = createDebugLogger('signaling')
+
+function makeWsUrl(path = '/api/ws') {
+  const loc = window.location
+  const isSecure = loc.protocol === 'https:'
+  const scheme = isSecure ? 'wss' : 'ws'
+  return `${scheme}://${loc.host}${path}`
+}
+
+type SignalingStatus = 'connecting' | 'open' | 'closed' | 'error' | 'reconnecting'
+
+type WsOpts = {
+  room: string
+  peerId: string
+  role: Role
+  onMessage: (data: SignalingServerMessage) => void
+  onStatus?: (s: SignalingStatus) => void
+}
+
+export function createSignaling({ room, peerId, role, onMessage, onStatus }: WsOpts) {
+  let ws: WebSocket | null = null
+  let retry = 0
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  let manuallyClosed = false
+
+  const connect = () => {
+    signalingLog.info('Connecting to signaling server', { room, peerId, role })
+    onStatus?.('connecting')
+    ws = new WebSocket(makeWsUrl('/api/ws'))
+
+    ws.onopen = () => {
+      signalingLog.info('WebSocket connected')
+      retry = 0
+      manuallyClosed = false
+      onStatus?.('open')
+      const payload = {
+        type: 'join' as const,
+        room,
+        peerId,
+        role
+      }
+      signalingLog.log('Sending join payload', payload)
+      ws!.send(JSON.stringify(payload))
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer)
+        reconnectTimer = null
+      }
+    }
+
+    ws.onmessage = async (event) => {
+      signalingLog.time('message-handling')
+      try {
+        const raw = await normalizeIncomingPayload(event.data)
+        if (!raw) {
+          signalingLog.warn('Received empty message from signaling server')
+          return
+        }
+
+        const parsed = JSON.parse(raw)
+        if (!isSignalingServerMessage(parsed)) {
+          signalingLog.warn('Received malformed message', { raw })
+          return
+        }
+
+        if (parsed.type === 'ping') {
+          signalingLog.log('↪️ Responding to ping heartbeat', parsed)
+          ws?.send(JSON.stringify({ type: 'pong' }))
+          return
+        }
+
+        signalingLog.log('Dispatching signaling message', parsed)
+        onMessage?.(parsed)
+      } catch (error) {
+        signalingLog.error('Failed to process WebSocket message', error)
+      } finally {
+        signalingLog.timeEnd('message-handling')
+      }
+    }
+
+    const scheduleReconnect = () => {
+      if (manuallyClosed) return
+      if (reconnectTimer) clearTimeout(reconnectTimer)
+      onStatus?.('reconnecting')
+      const delay = Math.min(30_000, 1_000 * Math.pow(2, retry++))
+      signalingLog.warn('Scheduling reconnect', { delay, retry })
+      ws = null
+      reconnectTimer = setTimeout(connect, delay)
+    }
+
+    ws.onerror = (error) => {
+      signalingLog.error('WebSocket error', error)
+      onStatus?.('error')
+      try {
+        ws?.close()
+      } catch (closeError) {
+        signalingLog.warn('Error closing socket after failure', closeError)
+      }
+    }
+
+    ws.onclose = (event) => {
+      signalingLog.warn('WebSocket closed', { code: event.code, reason: event.reason })
+      onStatus?.('closed')
+      ws = null
+      scheduleReconnect()
+    }
+  }
+
+  const send = (payload: unknown) => {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      signalingLog.log('Sending payload', payload)
+      ws.send(JSON.stringify(payload))
+    } else {
+      signalingLog.warn('Attempted to send payload while socket not open', { readyState: ws?.readyState })
+    }
+  }
+
+  const close = () => {
+    manuallyClosed = true
+    signalingLog.info('Closing signaling connection manually')
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer)
+      reconnectTimer = null
+    }
+    try {
+      ws?.close()
+    } catch (error) {
+      signalingLog.warn('Failed to close WebSocket cleanly', error)
+    }
+    ws = null
+  }
+
+  connect()
+
+  return { send, close }
+}
+
+async function normalizeIncomingPayload(payload: unknown): Promise<string> {
+  if (typeof payload === 'string') {
+    return payload
+  }
+
+  if (typeof Blob !== 'undefined' && payload instanceof Blob) {
+    return payload.text()
+  }
+
+  if (typeof ArrayBuffer !== 'undefined' && payload instanceof ArrayBuffer) {
+    return new TextDecoder('utf-8').decode(payload)
+  }
+
+  if (payload && ArrayBuffer.isView(payload)) {
+    return new TextDecoder('utf-8').decode(payload.buffer as ArrayBuffer)
+  }
+
+  signalingLog.warn('Unable to normalize incoming payload', { payloadType: typeof payload })
+  return ''
+}

--- a/src/app/classroom/[id]/live/utils/types.ts
+++ b/src/app/classroom/[id]/live/utils/types.ts
@@ -1,0 +1,61 @@
+export type Role = 'host' | 'viewer'
+
+export type RemotePeer = {
+  peerId: string
+  role?: Role
+}
+
+export type SignalingServerMessage =
+  | {
+      type: 'joined'
+      room: string
+      participants: number
+      peerId: string
+      role?: Role
+      peers?: RemotePeer[]
+    }
+  | {
+      type: 'left'
+      room: string
+      participants: number
+      peerId: string
+      role?: Role
+    }
+  | { type: 'peer'; from: string; payload: unknown }
+  | { type: 'error'; message: string }
+  | { type: 'ping'; timestamp?: number }
+  | { type: 'pong' }
+
+export type SignalPayload = {
+  type: string
+  target?: string
+  sdp?: string
+  candidate?: RTCIceCandidateInit
+  [key: string]: unknown
+}
+
+export type ConnectionStatus = 'idle' | 'initializing' | 'connecting' | 'connected' | 'error'
+
+export function isSignalPayload(value: unknown): value is SignalPayload {
+  return typeof value === 'object' && value !== null && 'type' in value
+}
+
+export function isSignalingServerMessage(value: unknown): value is SignalingServerMessage {
+  if (typeof value !== 'object' || value === null || !('type' in value)) {
+    return false
+  }
+
+  const { type } = value as { type?: unknown }
+  if (typeof type !== 'string') {
+    return false
+  }
+
+  return [
+    'joined',
+    'left',
+    'peer',
+    'error',
+    'ping',
+    'pong'
+  ].includes(type)
+}


### PR DESCRIPTION
## Summary
- extract live classroom signaling, ICE resolution, and shared types into focused utility modules
- add configurable debug logging helpers and wire them into the live classroom page for richer runtime tracing
- update the live classroom component to consume the new helpers, remove `any` casts, and improve reconnection handling
- harden ICE server resolution with memoization, environment parsing fallbacks, and debug logging for TURN/STUN configuration
- relax the `@typescript-eslint/no-require-imports` lint rule for operational Node scripts so repo-wide linting completes successfully

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e389313e648326a14232a83b4b148e