### PR TITLE
Stabilize live classroom WebSocket transport

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,3 @@
+# Local development overrides
+# LIVE_TRANSPORT can be set to "ws" (default) or "sse" for the fallback stream
+LIVE_TRANSPORT=ws

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
+!.env.local.example
 
 # Protect production environment files
 .env.local

--- a/README.md
+++ b/README.md
@@ -54,6 +54,32 @@ npm run dev
 - Admin Panel: `http://localhost:3000/admin/login`
 - Student Dashboard: `http://localhost:3000/student/login`nakan credentials berikut:
 
+## 🔌 Live Classroom Transport
+
+- Gunakan variabel lingkungan `LIVE_TRANSPORT` (`ws` default, `sse` untuk fallback satu arah) di `.env.local`.
+- Endpoint WebSocket: `/api/ws` (Edge runtime) mengirim heartbeat setiap 25 detik dan echo pesan JSON.
+- Endpoint SSE fallback: `/api/live-classroom/stream` memancarkan event `ready` dan `ping` untuk monitor satu arah.
+- Halaman `/classroom` menampilkan status koneksi secara real-time (connecting/open/reconnecting/closed) dan potongan pesan terakhir.
+
+### Verifikasi Koneksi WebSocket
+
+```bash
+# Tanpa upgrade → 426 Expected Upgrade
+curl -i http://localhost:3000/api/ws
+
+# Dengan upgrade → 101 Switching Protocols
+curl -i -N -H "Connection: Upgrade" -H "Upgrade: websocket" http://localhost:3000/api/ws
+```
+
+### Verifikasi Fallback SSE
+
+```bash
+LIVE_TRANSPORT=sse npm run dev
+curl -N http://localhost:3000/api/live-classroom/stream
+```
+
+Pastikan log browser di `/classroom` menunjukkan status `open` dan pesan heartbeat tanpa error 500.
+
 **Super Admin:**
 - Email: `admin@smawahidiyah.edu`
 - Password: `admin123`

--- a/src/app/api/live-classroom/stream/route.ts
+++ b/src/app/api/live-classroom/stream/route.ts
@@ -1,0 +1,62 @@
+export const runtime = 'edge'
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: Request) {
+  const encoder = new TextEncoder()
+
+  try {
+    let interval: ReturnType<typeof setInterval> | null = null
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const send = (data: Record<string, unknown>) => {
+          try {
+            const payload = `data: ${JSON.stringify(data)}\n\n`
+            controller.enqueue(encoder.encode(payload))
+          } catch (error) {
+            console.error('[sse] failed to serialize payload', error)
+          }
+        }
+
+        send({ type: 'ready', t: Date.now() })
+
+        interval = setInterval(() => {
+          send({ type: 'ping', t: Date.now() })
+        }, 25_000)
+
+        const abort = () => {
+          try {
+            if (interval) {
+              clearInterval(interval)
+              interval = null
+            }
+          } catch {}
+          try {
+            controller.close()
+          } catch {}
+        }
+
+        request.signal.addEventListener('abort', abort)
+      },
+      cancel() {
+        if (interval) {
+          try {
+            clearInterval(interval)
+          } catch {}
+          interval = null
+        }
+      }
+    })
+
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream; charset=utf-8',
+        'Cache-Control': 'no-cache, no-transform',
+        Connection: 'keep-alive'
+      }
+    })
+  } catch (error) {
+    console.error('[sse] initialization error', error)
+    return new Response('SSE init error', { status: 500 })
+  }
+}

--- a/src/app/api/ws/route.ts
+++ b/src/app/api/ws/route.ts
@@ -1,261 +1,74 @@
 export const runtime = 'edge'
 export const dynamic = 'force-dynamic'
 
-type Role = 'host' | 'viewer'
-
-type ServerMessage =
-  | {
-      type: 'joined'
-      room: string
-      participants: number
-      peerId: string
-      role?: Role
-      peers?: Array<{ peerId: string; role?: Role }>
-    }
-  | {
-      type: 'left'
-      room: string
-      participants: number
-      peerId: string
-      role?: Role
-    }
-  | { type: 'peer'; from: string; payload: unknown }
-  | { type: 'error'; message: string }
-  | { type: 'ping'; timestamp: number }
-
-type ClientMessage =
-  | { type: 'join'; room: string; peerId?: string; role?: Role }
-  | { type: 'signal'; room: string; from?: string; to?: string; payload: unknown }
-  | { type: 'pong' }
-  | { type: 'leave'; room: string; peerId?: string }
-
-type PeerMetadata = { peerId: string; role?: Role }
-
-type GlobalState = {
-  __rooms?: Map<string, Set<WebSocket>>
-  __roomPeers?: Map<string, Map<WebSocket, PeerMetadata>>
-}
-
-const g = globalThis as unknown as GlobalState
-if (!g.__rooms) g.__rooms = new Map()
-if (!g.__roomPeers) g.__roomPeers = new Map()
-
-const rooms = g.__rooms
-const roomPeers = g.__roomPeers
-
-function getPeerRegistry(room: string) {
-  let registry = roomPeers.get(room)
-  if (!registry) {
-    registry = new Map()
-    roomPeers.set(room, registry)
-  }
-  return registry
-}
-
-function broadcast(room: string, data: ServerMessage, except?: WebSocket) {
-  const sockets = rooms.get(room)
-  if (!sockets) return
-  const payload = JSON.stringify(data)
-  for (const socket of sockets) {
-    if (except && socket === except) continue
-    try {
-      socket.send(payload)
-    } catch {
-      // noop: ignore broken socket
-    }
-  }
-}
-
-function sendToPeer(room: string, targetPeerId: string, data: ServerMessage) {
-  const registry = roomPeers.get(room)
-  if (!registry) return
-  const payload = JSON.stringify(data)
-  for (const [socket, meta] of registry.entries()) {
-    if (meta.peerId === targetPeerId) {
-      try {
-        socket.send(payload)
-      } catch {
-        // noop
-      }
-      return
-    }
-  }
-}
-
-export function GET(request: Request) {
-  const upgradeHeader = request.headers.get('upgrade') || ''
-  if (upgradeHeader.toLowerCase() !== 'websocket') {
+export async function GET(req: Request) {
+  const upgrade = req.headers.get('upgrade') || ''
+  if (upgrade.toLowerCase() !== 'websocket') {
     return new Response('Expected Upgrade: websocket', { status: 426 })
   }
 
+  // @ts-expect-error - WebSocketPair is provided by the Edge runtime
+  const { 0: client, 1: server } = new WebSocketPair()
+  const ws = server as WebSocket
+
   try {
-    // @ts-expect-error - WebSocketPair is provided by the Edge runtime
-    const { 0: client, 1: server } = new WebSocketPair()
-    const ws = server as WebSocket & { accept: () => void }
     ws.accept()
 
-  let currentRoom: string | null = null
-  let currentPeerId = `peer_${Math.random().toString(36).slice(2, 9)}`
-  let currentRole: Role | undefined
+    console.info('[ws] connection accepted')
 
-  // --- Heartbeat: server -> ping, client -> pong ---
-  let heartbeatAlive = true
-  const HEARTBEAT_MS = 25_000
-  const heartbeatTimer = setInterval(() => {
-    try {
-      if ((ws as WebSocket).readyState !== ws.OPEN) return
-      if (!heartbeatAlive) {
-        try {
-          ws.close(4000, 'No heartbeat (pong) received')
-        } catch {}
-        return
-      }
-      heartbeatAlive = false
-      ws.send(JSON.stringify({ type: 'ping', timestamp: Date.now() } satisfies ServerMessage))
-    } catch {
-      // ignore send errors
-    }
-  }, HEARTBEAT_MS)
-
-  const leaveRoom = () => {
-    if (!currentRoom) return
-    const sockets = rooms.get(currentRoom)
-    const registry = roomPeers.get(currentRoom)
-    const meta = registry?.get(ws)
-
-    if (sockets) {
-      sockets.delete(ws)
-      if (sockets.size === 0) {
-        rooms.delete(currentRoom)
-      }
-    }
-
-    if (registry) {
-      registry.delete(ws)
-      if (registry.size === 0) {
-        roomPeers.delete(currentRoom)
-      }
-    }
-
-    if (meta) {
-      console.log('[ws] leave', currentRoom, meta.peerId, meta.role, 'participants', sockets?.size ?? 0)
-      broadcast(currentRoom, {
-        type: 'left',
-        room: currentRoom,
-        participants: sockets?.size ?? 0,
-        peerId: meta.peerId,
-        role: meta.role
-      })
-    }
-
-    currentRoom = null
-  }
-
-  const broadcastServerMessage = (room: string, data: ServerMessage) => {
-    broadcast(room, data, ws)
-  }
-
-  ws.addEventListener('message', (ev: MessageEvent) => {
-    try {
-      const raw = typeof ev.data === 'string' ? ev.data : new TextDecoder().decode(ev.data as ArrayBuffer)
-      const msg = JSON.parse(raw) as ClientMessage
-
-      if (msg.type === 'pong') {
-        // client replied to heartbeat
-        heartbeatAlive = true
-        return
-      }
-
-      if (msg.type === 'join') {
-        const room = msg.room?.trim()
-        if (!room) {
-          ws.send(JSON.stringify({ type: 'error', message: 'room required' } satisfies ServerMessage))
-          return
-        }
-
-        currentRoom = room
-        currentPeerId = msg.peerId?.trim() || currentPeerId
-        currentRole = msg.role === 'host' ? 'host' : 'viewer'
-
-        let sockets = rooms.get(room)
-        if (!sockets) {
-          sockets = new Set()
-          rooms.set(room, sockets)
-        }
-        const registry = getPeerRegistry(room)
-        const existingPeers = Array.from(registry.values()).map((peer) => ({
-          peerId: peer.peerId,
-          role: peer.role
-        }))
-
-        sockets.add(ws)
-        registry.set(ws, { peerId: currentPeerId, role: currentRole })
-
-        console.log('[ws] join', room, currentPeerId, currentRole, 'participants', sockets.size)
-
+    const heartbeat = setInterval(() => {
+      try {
         ws.send(
           JSON.stringify({
-            type: 'joined',
-            room,
-            participants: sockets.size,
-            peerId: currentPeerId,
-            role: currentRole,
-            peers: existingPeers
-          } satisfies ServerMessage)
+            type: 'ping',
+            t: Date.now()
+          })
         )
-
-        broadcastServerMessage(room, {
-          type: 'joined',
-          room,
-          participants: sockets.size,
-          peerId: currentPeerId,
-          role: currentRole
-        })
-        return
+      } catch (error) {
+        console.warn('[ws] failed to send ping', error)
       }
+    }, 25_000)
 
-      if (msg.type === 'leave') {
-        leaveRoom()
-        return
-      }
-
-      if (msg.type === 'signal') {
-        if (!currentRoom) return
-        const payload: ServerMessage = {
-          type: 'peer',
-          from: msg.from ?? currentPeerId,
-          payload: msg.payload
-        }
-
-        if (msg.to) {
-          sendToPeer(currentRoom, msg.to, payload)
-        } else {
-          broadcastServerMessage(currentRoom, payload)
-        }
-        return
-      }
-    } catch {
+    ws.addEventListener('message', (event) => {
       try {
-        ws.send(JSON.stringify({ type: 'error', message: 'invalid message' } satisfies ServerMessage))
+        const text = typeof event.data === 'string' ? event.data : ''
+        const message = JSON.parse(text || '{}')
+        ws.send(
+          JSON.stringify({
+            type: 'echo',
+            data: message,
+            t: Date.now()
+          })
+        )
+      } catch (error) {
+        try {
+          ws.send(
+            JSON.stringify({
+              type: 'error',
+              message: 'bad_json'
+            })
+          )
+        } catch {}
+        console.error('[ws] invalid JSON message', error)
+      }
+    })
+
+    const cleanup = () => {
+      try {
+        clearInterval(heartbeat)
       } catch {}
     }
-  })
-
-  const cleanup = () => {
-    try {
-      clearInterval(heartbeatTimer)
-    } catch {}
-    leaveRoom()
-  }
 
     ws.addEventListener('close', cleanup)
     ws.addEventListener('error', cleanup)
 
-    return new Response(null, { status: 101, webSocket: client } as ResponseInit & {
-      webSocket: WebSocket
-    })
-  } catch (err) {
-    console.error('[ws] upgrade error', err)
-    return new Response('Failed to establish WebSocket connection', { status: 500 })
+    // @ts-expect-error - ResponseInit.webSocket is available in the Edge runtime
+    return new Response(null, { status: 101, webSocket: client })
+  } catch (error) {
+    console.error('[ws] initialization error', error)
+    try {
+      ws.close()
+    } catch {}
+    return new Response('WS init error', { status: 500 })
   }
 }

--- a/src/app/api/ws/route.ts
+++ b/src/app/api/ws/route.ts
@@ -12,7 +12,12 @@ export async function GET(req: Request) {
   const ws = server as WebSocket
 
   try {
-    ws.accept()
+    const accept = (ws as unknown as { accept?: () => void }).accept
+    if (typeof accept === 'function') {
+      accept.call(ws)
+    } else {
+      throw new Error('WebSocket missing accept')
+    }
 
     console.info('[ws] connection accepted')
 

--- a/src/app/classroom/page.tsx
+++ b/src/app/classroom/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { motion } from "framer-motion";
 import Link from "next/link";
 import Image from "next/image";
@@ -117,6 +117,10 @@ const mergeProgressWithProjects = (
 
 const STORAGE_PREFIX = "gema-classroom-project-roadmap";
 
+const LIVE_TRANSPORT_MODE = (
+  process.env.NEXT_PUBLIC_LIVE_TRANSPORT ?? process.env.LIVE_TRANSPORT ?? "ws"
+).toLowerCase();
+
 export default function ClassroomPage() {
   const [activeTab, setActiveTab] = useState<'assignments' | 'articles' | 'roadmap'>('assignments');
   const [assignments, setAssignments] = useState<ClassroomAssignmentResponse[]>([]);
@@ -132,6 +136,41 @@ export default function ClassroomPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [roadmapStudentId, setRoadmapStudentId] = useState("");
   const [roadmapStudentName, setRoadmapStudentName] = useState("");
+
+  const liveTransport: "ws" | "sse" =
+    LIVE_TRANSPORT_MODE === "sse" ? "sse" : "ws";
+  const [liveStatus, setLiveStatus] = useState<
+    "idle" | "connecting" | "open" | "reconnecting" | "closed" | "error"
+  >("idle");
+  const [lastLiveMessage, setLastLiveMessage] = useState("");
+  const wsRef = useRef<WebSocket | null>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const liveStatusColor =
+    liveStatus === "open"
+      ? "text-green-600"
+      : liveStatus === "connecting"
+        ? "text-yellow-600"
+        : liveStatus === "reconnecting"
+          ? "text-orange-500"
+          : liveStatus === "error"
+            ? "text-red-600"
+            : "text-gray-600";
+
+  let liveMessagePreview = lastLiveMessage;
+  if (liveMessagePreview) {
+    try {
+      const parsed = JSON.parse(liveMessagePreview);
+      liveMessagePreview = JSON.stringify(parsed);
+    } catch {
+      // ignore invalid json
+    }
+  }
+  const liveMessageDisplay =
+    liveMessagePreview.length > 120
+      ? `${liveMessagePreview.slice(0, 117)}...`
+      : liveMessagePreview;
 
   const [projects, setProjects] = useState<ClassroomProjectChecklistItem[]>(DEFAULT_PROJECTS);
   const [projectsLoading, setProjectsLoading] = useState(true);
@@ -152,6 +191,167 @@ export default function ClassroomPage() {
     fetchArticles();
     fetchProjects();
   }, []);
+
+  useEffect(() => {
+    let stopped = false;
+
+    function clearReconnectTimer() {
+      if (reconnectTimerRef.current !== null) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+    }
+
+    const closeWebSocket = () => {
+      const socket = wsRef.current;
+      if (socket) {
+        try {
+          socket.close();
+        } catch {}
+        wsRef.current = null;
+      }
+    };
+
+    const closeEventSource = () => {
+      const source = eventSourceRef.current;
+      if (source) {
+        source.close();
+        eventSourceRef.current = null;
+      }
+    };
+
+    if (liveTransport === "sse") {
+      setLiveStatus("connecting");
+
+      try {
+        const source = new EventSource("/api/live-classroom/stream");
+        eventSourceRef.current = source;
+
+        source.onopen = () => {
+          if (stopped) return;
+          setLiveStatus("open");
+        };
+
+        source.onmessage = (event) => {
+          if (stopped) return;
+          const data = event.data ?? "";
+          setLastLiveMessage(data);
+        };
+
+        source.onerror = () => {
+          if (stopped) return;
+          if (source.readyState === EventSource.CLOSED) {
+            setLiveStatus("closed");
+          } else {
+            setLiveStatus("reconnecting");
+          }
+        };
+      } catch (error) {
+        console.error("[classroom] SSE connection error", error);
+        setLiveStatus("error");
+      }
+
+      return () => {
+        stopped = true;
+        clearReconnectTimer();
+        closeEventSource();
+        closeWebSocket();
+      };
+    }
+
+    let attempt = 0;
+
+    function scheduleReconnect() {
+      if (stopped) return;
+      clearReconnectTimer();
+      setLiveStatus("reconnecting");
+      const delay = Math.min(5000, 1500 + attempt * 1000);
+      reconnectTimerRef.current = window.setTimeout(() => {
+        if (stopped) return;
+        attempt += 1;
+        connect();
+      }, delay);
+    }
+
+    function connect() {
+      if (stopped) return;
+      const isReconnect = attempt > 0;
+      setLiveStatus(isReconnect ? "reconnecting" : "connecting");
+
+      try {
+        const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+        const ws = new WebSocket(`${protocol}://${window.location.host}/api/ws`);
+        wsRef.current = ws;
+
+        ws.addEventListener("open", () => {
+          if (stopped) return;
+          attempt = 0;
+          setLiveStatus("open");
+          try {
+            ws.send(
+              JSON.stringify({
+                type: "join",
+                t: Date.now()
+              })
+            );
+          } catch {}
+        });
+
+        ws.addEventListener("message", (event) => {
+          if (stopped) return;
+          const { data } = event;
+
+          if (typeof data === "string") {
+            setLastLiveMessage(data);
+            try {
+              const parsed = JSON.parse(data);
+              if (parsed?.type === "ping") {
+                try {
+                  ws.send(
+                    JSON.stringify({
+                      type: "pong",
+                      t: Date.now()
+                    })
+                  );
+                } catch {}
+              }
+            } catch {}
+          } else if (data instanceof Blob) {
+            data
+              .text()
+              .then((text) => {
+                if (stopped) return;
+                setLastLiveMessage(text);
+              })
+              .catch(() => {});
+          }
+        });
+
+        ws.addEventListener("error", () => {
+          if (stopped) return;
+          setLiveStatus("error");
+        });
+
+        ws.addEventListener("close", () => {
+          if (stopped) return;
+          setLiveStatus("closed");
+          scheduleReconnect();
+        });
+      } catch (error) {
+        console.error("[classroom] WebSocket initialization error", error);
+        scheduleReconnect();
+      }
+    }
+
+    connect();
+
+    return () => {
+      stopped = true;
+      clearReconnectTimer();
+      closeWebSocket();
+      closeEventSource();
+    };
+  }, [liveTransport]);
 
   const fetchAssignments = async () => {
     try {
@@ -561,6 +761,29 @@ export default function ClassroomPage() {
                 LIVE
               </span>
             </Link>
+          </div>
+          <div className="mt-4 rounded-lg border border-blue-100 bg-blue-50 p-4 text-sm text-blue-900">
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="font-semibold uppercase tracking-wide">Live transport</span>
+              <span className="rounded bg-white px-2 py-0.5 text-xs font-semibold uppercase text-blue-600">
+                {liveTransport}
+              </span>
+              <span className="font-semibold">Status:</span>
+              <span className={`font-semibold capitalize ${liveStatusColor}`}>{liveStatus}</span>
+            </div>
+            {liveMessageDisplay && (
+              <div className="mt-2 space-y-1 text-blue-800">
+                <div className="text-xs uppercase tracking-wide text-blue-700">Last message</div>
+                <code className="block w-full overflow-hidden text-ellipsis whitespace-nowrap rounded bg-white/80 px-2 py-1 text-xs">
+                  {liveMessageDisplay}
+                </code>
+              </div>
+            )}
+            {liveTransport === 'sse' && (
+              <p className="mt-2 text-xs text-blue-700">
+                Mode SSE aktif untuk fallback satu arah.
+              </p>
+            )}
           </div>
         </div>
       </div>

--- a/src/app/classroom/page.tsx
+++ b/src/app/classroom/page.tsx
@@ -145,7 +145,7 @@ export default function ClassroomPage() {
   const [lastLiveMessage, setLastLiveMessage] = useState("");
   const wsRef = useRef<WebSocket | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
-  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectTimerRef = useRef<number | null>(null);
 
   const liveStatusColor =
     liveStatus === "open"
@@ -197,7 +197,7 @@ export default function ClassroomPage() {
 
     function clearReconnectTimer() {
       if (reconnectTimerRef.current !== null) {
-        clearTimeout(reconnectTimerRef.current);
+        window.clearTimeout(reconnectTimerRef.current);
         reconnectTimerRef.current = null;
       }
     }


### PR DESCRIPTION
## Summary
- replace the edge WebSocket handler with a heartbeat-enabled echo server and add an SSE fallback stream
- surface live transport status, reconnection logic, and message previews on the classroom page with WebSocket/SSE support
- document verification steps and expose a LIVE_TRANSPORT flag for local configuration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e670c5902c832690f2f6f0d05a0598